### PR TITLE
Fix "hier" mode hwif generation 

### DIFF
--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -17,7 +17,7 @@ class InputStructGenerator_Hier(RDLFlatStructGenerator):
 
     def get_typdef_name(self, node:'Node') -> str:
         base = node.get_rel_path(
-            self.top_node.parent,
+            self.top_node,
             hier_separator="__",
             array_suffix="x",
             empty_array_suffix="x"
@@ -73,13 +73,14 @@ class InputStructGenerator_Hier(RDLFlatStructGenerator):
 
 
 class OutputStructGenerator_Hier(RDLFlatStructGenerator):
-    def __init__(self, top_node: 'Node'):
+    def __init__(self, hwif: 'Hwif') -> None:
         super().__init__()
-        self.top_node = top_node
+        self.hwif = hwif
+        self.top_node = hwif.top_node
 
     def get_typdef_name(self, node:'Node') -> str:
         base = node.get_rel_path(
-            self.top_node.parent,
+            self.top_node,
             hier_separator="__",
             array_suffix="x",
             empty_array_suffix="x"

--- a/tests/lib/base_testcase.py
+++ b/tests/lib/base_testcase.py
@@ -33,6 +33,7 @@ class BaseTestCase(unittest.TestCase):
     # Other exporter args:
     retime_read_fanin = False
     retime_read_response = False
+    reuse_hwif_typedefs = True
 
     #: this gets auto-loaded via the _load_request autouse fixture
     request = None # type: pytest.FixtureRequest
@@ -94,6 +95,7 @@ class BaseTestCase(unittest.TestCase):
             cpuif_cls=cls.cpuif.cpuif_cls,
             retime_read_fanin=cls.retime_read_fanin,
             retime_read_response=cls.retime_read_response,
+            reuse_hwif_typedefs=cls.reuse_hwif_typedefs
         )
 
     @classmethod


### PR DESCRIPTION
Using the --type-style=hier option on the peakrdl command line tool was broken due to bugs in OutputStructGenerator_Hier/InputStructGenerator_Hier. 

These were not caught in tests due to issues with the test parameterization code.