### PR TITLE
Store previous data and the strobe in wbuf_storage

### DIFF
--- a/src/peakrdl_regblock/write_buffering/template.sv
+++ b/src/peakrdl_regblock/write_buffering/template.sv
@@ -14,8 +14,8 @@ always_ff {{get_always_ff_event(cpuif.reset)}} begin
             {{wbuf_prefix}}.data{{segment.bslice}} <= decoded_wr_data_bswap;
             {{wbuf_prefix}}.biten{{segment.bslice}} <= decoded_wr_biten_bswap;
             {%- else %}
-            {{wbuf_prefix}}.data{{segment.bslice}} <= decoded_wr_data;
-            {{wbuf_prefix}}.biten{{segment.bslice}} <= decoded_wr_biten;
+            {{wbuf_prefix}}.data{{segment.bslice}} <= ({{wbuf_prefix}}.data{{segment.bslice}} & ~decoded_wr_biten{{segment.bslice}}) | (decoded_wr_data{{segment.bslice}} & decoded_wr_biten{{segment.bslice}});
+            {{wbuf_prefix}}.biten{{segment.bslice}} <= decoded_wr_biten | {{wbuf_prefix}}.biten{{segment.bslice}};
             {%- endif %}
         end
         {%- endfor %}


### PR DESCRIPTION
Not sure if the fix is correct, but I think there is a bug with https://peakrdl-regblock.readthedocs.io/en/latest/udps/write_buffering.html#
The strobe is not respected on subsequent writes to a buffered register.
This is what I get in simulation.
![2023-04-29T18:31:53,694039990+02:00](https://user-images.githubusercontent.com/8126577/235313923-7d68ebaa-773c-4264-9c95-e85009ea86cc.png)

Here is what I expect and what the fixed version does.
![2023-04-29T18:32:24,408363846+02:00](https://user-images.githubusercontent.com/8126577/235313988-ef729b3d-9636-4f03-9818-8fd13e367287.png)

If its correct I should probably do it also for decoded_wr_data_bswap, I didn't check what that one is...