### PR TITLE
Fixing write strobe width

### DIFF
--- a/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
+++ b/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
@@ -8,7 +8,7 @@ logic axil_awvalid;
 logic [{{cpuif.addr_width-1}}:0] axil_awaddr;
 logic axil_wvalid;
 logic [{{cpuif.data_width-1}}:0] axil_wdata;
-logic [{{cpuif.data_width-1}}:0] axil_wstrb;
+logic [{{cpuif.data_width_bytes-1}}:0] axil_wstrb;
 logic axil_aw_accept;
 logic axil_resp_acked;
 

--- a/tests/lib/sim_testcase.py
+++ b/tests/lib/sim_testcase.py
@@ -5,11 +5,12 @@ import jinja2 as jj
 from .sv_line_anchor import SVLineAnchor
 
 from .simulators.questa import Questa
+from .simulators.vcs import Vcs
 from .simulators import StubSimulator
 
 from .base_testcase import BaseTestCase
 
-SIM_CLS = Questa
+SIM_CLS = Vcs
 if os.environ.get("STUB_SIMULATOR", False):
     SIM_CLS = StubSimulator
 

--- a/tests/lib/simulators/vcs.py
+++ b/tests/lib/simulators/vcs.py
@@ -1,0 +1,55 @@
+from typing import List
+import subprocess
+import os
+
+from . import Simulator
+
+
+class Vcs(Simulator):
+    def compile(self) -> None:
+        cmd = [
+            "vcs", "-full64", "-sverilog", "+systemverilogext+2017", "-quiet", "-l", "build.log",
+
+            "+incdir+%s" % os.path.join(os.path.dirname(__file__), ".."),
+
+            "-override_timescale=1ns/1ps",
+
+            # Log waves
+            "+define+WAVES_FSDB", '+define+WAVES=\"fsdb\"',
+        ]
+
+        # Add source files
+        cmd.extend(self.tb_files)
+
+        # Run command!
+        subprocess.run(cmd, check=True)
+
+
+    def run(self, plusargs:List[str] = None) -> None:
+        plusargs = plusargs or []
+
+        test_name = self.testcase_cls_inst.request.node.name
+
+        # call vsim
+        cmd = [
+            "./simv", "-quiet",
+            "-cm line+cond+tgl+fsm+branch+assert", "+enable_coverage=1",
+            "-l", "%s.log" % test_name,
+            "tb",
+        ]
+        for plusarg in plusargs:
+            cmd.append("+" + plusarg)
+        subprocess.run(cmd, check=True)
+
+        self.assertSimLogPass("%s.log" % test_name)
+
+
+    def assertSimLogPass(self, path: str):
+        self.testcase_cls_inst.assertTrue(os.path.isfile(path))
+
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("# ** Error"):
+                    self.testcase_cls_inst.fail(line)
+                elif line.startswith("# ** Fatal"):
+                    self.testcase_cls_inst.fail(line)

--- a/tests/test_structural_sw_rw/tb_template.sv
+++ b/tests/test_structural_sw_rw/tb_template.sv
@@ -73,11 +73,11 @@
     // rw_reg_lsb0
     `ifndef XSIM
         // Xilinx simulator has poor support for streaming operators. Skip
-        cpuif.assert_read('h3004, 0);
+	cpuif.assert_read('h3004, 0);
         cpuif.write('h3004, 'h4DEAB000);
         @cb;
-        assert({<<{cb.hwif_out.rw_reg_lsb0.f1.value}} == 8'hAB);
-        assert({<<{cb.hwif_out.rw_reg_lsb0.f2.value}} == 11'h4DE);
+        assert($bits({<<{cb.hwif_out.rw_reg_lsb0.f1.value}}) == 8'hAB);
+        assert($bits({<<{cb.hwif_out.rw_reg_lsb0.f2.value}}) == 11'h4DE);
         cpuif.assert_read('h3004, 'h4DEAB000);
     `endif
 {% endblock %}

--- a/tests/test_wide_regs/tb_template.sv
+++ b/tests/test_wide_regs/tb_template.sv
@@ -50,10 +50,10 @@
     cpuif.write('h14, 'h9ABC);
     cpuif.write('h16, 'hDEF1);
     @cb;
-    assert({<<{cb.hwif_out.rw_reg1_lsb0.f1.value}} == 8'h34);
-    assert({<<{cb.hwif_out.rw_reg1_lsb0.f2.value}} == 3'h1);
-    assert({<<{cb.hwif_out.rw_reg1_lsb0.f3.value}} == 1'h1);
-    assert({<<{cb.hwif_out.rw_reg1_lsb0.f4.value}} == 8'h9A);
+    assert($bits({<<{cb.hwif_out.rw_reg1_lsb0.f1.value}}) == 8'h34);
+    assert($bits({<<{cb.hwif_out.rw_reg1_lsb0.f2.value}}) == 3'h1);
+    assert($bits({<<{cb.hwif_out.rw_reg1_lsb0.f3.value}}) == 1'h1);
+    assert($bits({<<{cb.hwif_out.rw_reg1_lsb0.f4.value}}) == 8'h9A);
     cpuif.assert_read('h10, 'h1034);
     cpuif.assert_read('h12, 'h0000);
     cpuif.assert_read('h14, 'h9A10);
@@ -67,8 +67,8 @@
     cpuif.write('h1C, 'h9ABC);
     cpuif.write('h1E, 'hDEF1);
     @cb;
-    assert({<<{cb.hwif_out.rw_reg2_lsb0.f1.value}} == 4'h8);
-    assert({<<{cb.hwif_out.rw_reg2_lsb0.f2.value}} == 16'hDEF1);
+    assert($bits({<<{cb.hwif_out.rw_reg2_lsb0.f1.value}}) == 4'h8);
+    assert($bits({<<{cb.hwif_out.rw_reg2_lsb0.f2.value}}) == 16'hDEF1);
     cpuif.assert_read('h18, 'h0000);
     cpuif.assert_read('h1A, 'h0008);
     cpuif.assert_read('h1C, 'h0000);

--- a/tests/test_write_buffer/tb_template.sv
+++ b/tests/test_write_buffer/tb_template.sv
@@ -69,7 +69,7 @@
     assert(cb.hwif_out.reg1_msb0.f1.value == 0);
     cpuif.write('hE, 'hDEF1);
     @cb; @cb;
-    assert({<<{cb.hwif_out.reg1_msb0.f1.value}} == 64'hDEF19ABC56781234);
+    assert($bits({<<{cb.hwif_out.reg1_msb0.f1.value}}) == 64'hDEF19ABC56781234);
     cpuif.assert_read('h8, 'h1234);
     cpuif.assert_read('hA, 'h5678);
     cpuif.assert_read('hC, 'h9ABC);
@@ -104,8 +104,8 @@
     assert(cb.hwif_out.reg2_msb0.f2.value == 0);
     cpuif.write('h16, 'hAA12);
     @cb; @cb;
-    assert({<<{cb.hwif_out.reg2_msb0.f1.value}} == 12'h234);
-    assert({<<{cb.hwif_out.reg2_msb0.f2.value}} == 4'h1);
+    assert($bits({<<{cb.hwif_out.reg2_msb0.f1.value}}) == 12'h234);
+    assert($bits({<<{cb.hwif_out.reg2_msb0.f2.value}}) == 4'h1);
     cpuif.assert_read('h14, 'h3400);
     cpuif.assert_read('h16, 'h0012);
 
@@ -281,7 +281,7 @@
     cpuif.assert_read('hA, 'h0200);
     cpuif.assert_read('hC, 'h0070);
     cpuif.assert_read('hE, 'h0002);
-    assert({<<{cb.hwif_out.reg1_msb0.f1.value}} == 'h0002_0070_0200_A000);
+    assert($bits({<<{cb.hwif_out.reg1_msb0.f1.value}}) == 'h0002_0070_0200_A000);
 
     // Check that strobes are cumulative
     cpuif.write('h8, 'h0030, 'h00F0);
@@ -297,7 +297,7 @@
     cpuif.assert_read('hA, 'h0278);
     cpuif.assert_read('hC, 'hA07D);
     cpuif.assert_read('hE, 'hAF02);
-    assert({<<{cb.hwif_out.reg1_msb0.f1.value}} == 'hAF02_A07D_0278_A230);
+    assert($bits({<<{cb.hwif_out.reg1_msb0.f1.value}}) == 'hAF02_A07D_0278_A230);
 
 
 {% endblock %}


### PR DESCRIPTION
Hi,

1. Issue identified by running linting `verilator --lint-only generated_file.sv`. 
```
%Warning-WIDTH: regs/axi4/example_block.sv:100:28: Operator ASSIGNDLY expects 32 bits on the Assign RHS, but Assign RHS's VARREF 's_axil_wstrb' generates 4 bits.
                                                    : ... In instance example_block
  100 |                 axil_wstrb <= s_axil_wstrb;
```

It looks to me `cpuif.data_width_bytes` is the right value for the job but happy to be corrected.

2. Adding VCS support (VCS is less permissive in terms of casting/etc). Implementing minor fixes to casting.
