### PR TITLE
Change SV sturcts to packed

### DIFF
--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -34,7 +34,7 @@ class _AnonymousStruct(_StructBase):
             suffix = ""
 
         return (
-            "struct {\n"
+            "struct packed {\n"
             + super().__str__()
             + f"\n}} {self.inst_name}{suffix};"
         )
@@ -49,7 +49,7 @@ class _TypedefStruct(_StructBase):
 
     def __str__(self) -> str:
         return (
-            "typedef struct {\n"
+            "typedef struct packed {\n"
             + super().__str__()
             + f"\n}} {self.type_name};"
         )


### PR DESCRIPTION
Using packed structs make it a lot easier to handle when integrating into an existing design. Unless there is a specific reason not to use packed structs, I suggest merging this change.