### PR TITLE
Cpuif properties #77

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ Links
     :caption: Extended Properties
 
     udps/intro
+    udps/cpuif
     udps/read_buffering
     udps/write_buffering
     udps/extended_swacc

--- a/docs/udps/cpuif.rst
+++ b/docs/udps/cpuif.rst
@@ -1,0 +1,51 @@
+.. _cpuif:
+
+CPU Interface
+=============
+
+Properties
+----------
+The CPU interface for the registers can be specified with the following properties:
+
+.. literalinclude:: ../../hdl-src/regblock_udps.rdl
+    :lines: 40-48
+
+This UDP definition, along with others supported by PeakRDL-regblock can be
+enabled by compiling the following file along with your design:
+:download:`regblock_udps.rdl <../../hdl-src/regblock_udps.rdl>`.
+
+.. describe:: cpuif
+
+    *   Assigned value is a string.
+    *   Specifies the CPU interface type to access the registers.
+
+.. describe:: addrwidth
+
+    *   Assigned value is a longint unsigned.
+    *   Specifies the width of the CPU interface's address bus.
+
+Example
+-------
+
+In this example, an axi4-lite CPU interface is specified with an address bus
+width of 8.
+
+.. code-block:: systemrdl
+    :emphasize-lines: 4
+
+    addrmap top {
+        cpuif = "axi4-lite";
+        addrwidth = 8;
+
+        reg {
+            field {} rst;
+            field {} en;
+            field {} start;
+            field {} stop;
+        } control;
+
+        reg {
+            field {} running;
+            field {} done;
+        } status;
+    };

--- a/docs/udps/intro.rst
+++ b/docs/udps/intro.rst
@@ -19,6 +19,20 @@ To enable these UDPs, compile this RDL file prior to the rest of your design:
         - Type
         - Description
 
+    *   - cpuif
+        - addrmap
+        - string
+        - Specifies the CPU interface type.
+
+          See: :ref:`cpuif`.
+
+    *   - addrwidth
+        - addrmap
+        - longint unsigned
+        - Specifies the address with of the CPU interface.
+
+          See: :ref:`cpuif`.
+
     *   - buffer_reads
         - reg
         - boolean

--- a/hdl-src/regblock_udps.rdl
+++ b/hdl-src/regblock_udps.rdl
@@ -36,3 +36,13 @@ property wr_swacc {
     component = field;
     type = boolean;
 };
+
+property cpuif {
+    component = addrmap;
+    type = string;
+};
+
+property addrwidth {
+    component = addrmap;
+    type = longint unsigned;
+};

--- a/src/peakrdl_regblock/udps/__init__.py
+++ b/src/peakrdl_regblock/udps/__init__.py
@@ -1,6 +1,7 @@
 from .rw_buffering import BufferWrites, WBufferTrigger
 from .rw_buffering import BufferReads, RBufferTrigger
 from .extended_swacc import ReadSwacc, WriteSwacc
+from .cpuif import CpuIf, AddrWidth
 
 ALL_UDPS = [
     BufferWrites,
@@ -9,4 +10,6 @@ ALL_UDPS = [
     RBufferTrigger,
     ReadSwacc,
     WriteSwacc,
+    CpuIf,
+    AddrWidth,
 ]

--- a/src/peakrdl_regblock/udps/cpuif.py
+++ b/src/peakrdl_regblock/udps/cpuif.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING, Any
+
+from systemrdl.udp import UDPDefinition
+from systemrdl.component import Addrmap
+
+if TYPE_CHECKING:
+    from systemrdl.node import Node
+
+class CpuIf(UDPDefinition):
+    name = "cpuif"
+    valid_components = {Addrmap}
+    valid_type = str
+
+    def get_unassigned_default(self, node: 'Node') -> Any:
+        return None
+
+
+class AddrWidth(UDPDefinition):
+    name = "addrwidth"
+    valid_components = {Addrmap}
+    valid_type = int
+
+    def get_unassigned_default(self, node: 'Node') -> Any:
+        return None


### PR DESCRIPTION
I added user-defined properties for specifying the CPU interface. The properties are `cpuif` and `addrwidth`. The command line still has the highest priority for backward compatibility.

Example.
```systemrdl
addrmap top {
    cpuif = "axi4-lite";
    addrwidth = 4;

    reg {
        . . .
    }
};
```