### PR TITLE
Fix `regwidth` & `accesswidth` on buffer triggers when trigger is a `RegNode`

### DIFF
--- a/src/peakrdl_regblock/read_buffering/__init__.py
+++ b/src/peakrdl_regblock/read_buffering/__init__.py
@@ -37,8 +37,8 @@ class ReadBuffering:
         if isinstance(trigger, RegNode):
             # Trigger is a register.
             # trigger when lowermost address of the register is written
-            regwidth = node.get_property('regwidth')
-            accesswidth = node.get_property('accesswidth')
+            regwidth = trigger.get_property('regwidth')
+            accesswidth = trigger.get_property('accesswidth')
             strb_prefix = self.exp.dereferencer.get_access_strobe(trigger, reduce_substrobes=False)
 
             if accesswidth < regwidth:

--- a/src/peakrdl_regblock/write_buffering/__init__.py
+++ b/src/peakrdl_regblock/write_buffering/__init__.py
@@ -49,8 +49,8 @@ class WriteBuffering:
         if isinstance(trigger, RegNode):
             # Trigger is a register.
             # trigger when uppermost address of the register is written
-            regwidth = node.get_property('regwidth')
-            accesswidth = node.get_property('accesswidth')
+            regwidth = trigger.get_property('regwidth')
+            accesswidth = trigger.get_property('accesswidth')
             strb_prefix = self.exp.dereferencer.get_access_strobe(trigger, reduce_substrobes=False)
 
             if accesswidth < regwidth:


### PR DESCRIPTION
Currently, in `get_trigger` in the `ReadBuffering` and `WriteBuffering` classes when a read/write buffer trigger is of type `RegNode`,  the `RegNode` that will be stored is being used to determine the `regwidth` and `accesswidth` of the trigger. This is being used to determine how to access the trigger, this is incorrect when the trigger is not the node being stored. Instead, the trigger's properties should be used to determine how to access it.

For example, the code snippet (assuming `default accesswidth=32; default regwidth=32`):
```
reg {
    field {} trigger_reg_field[32];
} trigger_reg;

reg {
    sw =r; hw = w;
    regwidth = 128;
    field reg_field[128];
} my_reg;

my_reg->buffer_reads = true;
my_reg->rbuffer_trigger = trigger_reg;
```

Would generate code that look like:
```
// note: decoded_reg_strb.trigger_reg is of type `logic` not `logic [0:0]`
always_ff @(posedge clk) begin
    if (decoded_reg_strb.trigger_reg[0] && !decoded_req_is_wr) begin
        rbuf.my_reg.reg_field[127:0] <= hwif_in.my_reg.reg_field[127:0];
   end
end
```

Here, the access to `decoded_reg_strb.trigger_reg[0]` would be illegal (at least Questa doesn't permit it), but it would be generated as so because `my_reg.accesswidth` < `my_reg.regwidth`.
In truth it's `trigger_reg.accesswidth` and `trigger_reg.regwidth` that should be compared to get the correct access to the trigger.


