### PR TITLE
make field_logic.get_next_q_identifier register independent of reset

### DIFF
--- a/src/peakrdl_regblock/field_logic/templates/field_storage.sv
+++ b/src/peakrdl_regblock/field_logic/templates/field_storage.sv
@@ -61,8 +61,9 @@ always_ff @(posedge clk) begin
         {{field_logic.get_parity_identifier(node)}} <= ^{{field_logic.get_field_combo_identifier(node, "next")}};
         {%- endif %}
     end
-
+ end
     {%- if field_logic.has_next_q(node) %}
+always_ff @(posedge clk) begin
     {{field_logic.get_next_q_identifier(node)}} <= {{get_input_identifier(node)}};
-    {%- endif %}
 end
+    {%- endif %}


### PR DESCRIPTION
If an asynchronous reset is employed, the value of field_logic.get_next_q_identifier gets updated when the reset signal changes, even though the clock hasn't changed. This causes an unwanted update in the register. This change makes the register independent of the reset signal (removes the reset signal from its sensitivity list).