### PR TITLE
d.trifonov/cpuif err

### DIFF
--- a/src/peakrdl_regblock/addr_decode.py
+++ b/src/peakrdl_regblock/addr_decode.py
@@ -176,6 +176,8 @@ class DecodeLogicGenerator(RDLForLoopGenerator):
             rhs = f"cpuif_req_masked & (cpuif_addr == {self._get_address_str(node)})"
             s = f"{self.addr_decode.get_access_strobe(node)} = {rhs};"
             self.add_content(s)
+            # Add address decoding flag
+            self.add_content(f"is_decoded |= {self.addr_decode.get_access_strobe(node)};")
             if node.external:
                 readable = node.has_sw_readable
                 writable = node.has_sw_writable
@@ -195,6 +197,8 @@ class DecodeLogicGenerator(RDLForLoopGenerator):
                 rhs = f"cpuif_req_masked & (cpuif_addr == {self._get_address_str(node, subword_offset=(i*subword_stride))})"
                 s = f"{self.addr_decode.get_access_strobe(node)}[{i}] = {rhs};"
                 self.add_content(s)
+                # Add address decoding flag
+                self.add_content(f"is_decoded |= {self.addr_decode.get_access_strobe(node)}[{i}];")
                 if node.external:
                     readable = node.has_sw_readable
                     writable = node.has_sw_writable

--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -118,6 +118,9 @@ class RegblockExporter:
             If overriden to True, default reset is active-low instead of active-high.
         default_reset_async: bool
             If overriden to True, default reset is asynchronous instead of synchronous.
+        generate_cpuif_err: bool
+            If overriden to True: If the address is decoded incorrectly, the cpuif response
+            signal shows an error. For example: APB.PSLVERR = 1'b1, AXI4LITE.*RESP = 2'b10.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):

--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -227,6 +227,9 @@ class DesignState:
         self.default_reset_activelow = kwargs.pop("default_reset_activelow", False) # type: bool
         self.default_reset_async = kwargs.pop("default_reset_async", False) # type: bool
 
+        # Generating a cpuif error
+        self.generate_cpuif_err = kwargs.pop("generate_cpuif_err", False) # type: bool
+
         #------------------------
         # Info about the design
         #------------------------

--- a/src/peakrdl_regblock/module_tmpl.sv
+++ b/src/peakrdl_regblock/module_tmpl.sv
@@ -138,11 +138,11 @@ module {{ds.module_name}}
 
     always_comb begin
         automatic logic is_decoded;
-        is_decoded = '0;
     {%- if ds.has_external_addressable %}
         automatic logic is_external;
         is_external = '0;
     {%- endif %}
+        is_decoded = '0;
         {{address_decode.get_implementation()|indent(8)}}
         undecoded_addr_strb = ~is_decoded & decoded_req;
     {%- if ds.has_external_addressable %}

--- a/src/peakrdl_regblock/readback/templates/readback.sv
+++ b/src/peakrdl_regblock/readback/templates/readback.sv
@@ -29,12 +29,15 @@ end
 
 logic [{{cpuif.data_width-1}}:0] readback_array_r[{{fanin_array_size}}];
 logic readback_done_r;
+logic readback_err_r;
 always_ff {{get_always_ff_event(cpuif.reset)}} begin
     if({{get_resetsignal(cpuif.reset)}}) begin
         for(int i=0; i<{{fanin_array_size}}; i++) readback_array_r[i] <= '0;
         readback_done_r <= '0;
+        readback_err_r <= '0;
     end else begin
         readback_array_r <= readback_array_c;
+        readback_err_r <= undecoded_addr_strb;
         {%- if ds.has_external_addressable %}
         readback_done_r <= decoded_req & ~decoded_req_is_wr & ~decoded_strb_is_external;
         {%- else %}
@@ -48,7 +51,7 @@ always_comb begin
     automatic logic [{{cpuif.data_width-1}}:0] readback_data_var;
     readback_done = readback_done_r;
     {%- if ds.generate_cpuif_err %}
-    readback_err = readback_done & undecoded_addr_strb;
+    readback_err = readback_err_r;
     {%- else %}
     readback_err = '0;
     {%- endif %}
@@ -68,7 +71,7 @@ always_comb begin
     readback_done = decoded_req & ~decoded_req_is_wr;
     {%- endif %}
     {%- if ds.generate_cpuif_err %}
-    readback_err = readback_done & undecoded_addr_strb;
+    readback_err = undecoded_addr_strb;
     {%- else %}
     readback_err = '0;
     {%- endif %}
@@ -84,7 +87,7 @@ end
 assign readback_done = decoded_req & ~decoded_req_is_wr;
 assign readback_data = '0;
 {%- if ds.generate_cpuif_err %}
-assign readback_err = readback_done & undecoded_addr_strb;
+assign readback_err = undecoded_addr_strb;
 {%- else %}
 assign readback_err = '0;
 {%- endif %}

--- a/src/peakrdl_regblock/readback/templates/readback.sv
+++ b/src/peakrdl_regblock/readback/templates/readback.sv
@@ -47,7 +47,11 @@ end
 always_comb begin
     automatic logic [{{cpuif.data_width-1}}:0] readback_data_var;
     readback_done = readback_done_r;
+    {%- if ds.generate_cpuif_err %}
+    readback_err = readback_done & undecoded_addr_strb;
+    {%- else %}
     readback_err = '0;
+    {%- endif %}
     readback_data_var = '0;
     for(int i=0; i<{{fanin_array_size}}; i++) readback_data_var |= readback_array_r[i];
     readback_data = readback_data_var;
@@ -63,7 +67,11 @@ always_comb begin
     {%- else %}
     readback_done = decoded_req & ~decoded_req_is_wr;
     {%- endif %}
+    {%- if ds.generate_cpuif_err %}
+    readback_err = readback_done & undecoded_addr_strb;
+    {%- else %}
     readback_err = '0;
+    {%- endif %}
     readback_data_var = '0;
     for(int i=0; i<{{array_size}}; i++) readback_data_var |= readback_array[i];
     readback_data = readback_data_var;
@@ -75,5 +83,9 @@ end
 {%- else %}
 assign readback_done = decoded_req & ~decoded_req_is_wr;
 assign readback_data = '0;
+{%- if ds.generate_cpuif_err %}
+assign readback_err = readback_done & undecoded_addr_strb;
+{%- else %}
 assign readback_err = '0;
+{%- endif %}
 {% endif %}


### PR DESCRIPTION
I propose a new feature: the ability to enable response with an error if the address was decoded incorrectly.

Sometimes it is necessary to describe a register map so that there is empty space between addresses. For example, when IP has different configurations and one of the registers is not used in all. Typically we use "is_present" in this case. The programmer will access a non-existent address and expect some kind of response. But the transaction will complete normally. This may lengthen the time it takes to detect a software bug.

My proposal should speed up the process of debugging such cases. Our team always uses this approach, having learned it from the Big Three vendors. Typically their IPs follow this rule.