### PR TITLE
Fix spyglass warning and add options

### DIFF
--- a/src/peakrdl_regblock/__peakrdl__.py
+++ b/src/peakrdl_regblock/__peakrdl__.py
@@ -158,6 +158,14 @@ class Exporter(ExporterSubcommandPlugin):
             is active-high and synchronous [rst]"""
         )
 
+        arg_group.add_argument(
+            "--ext-strobe-assert-guard-macro",
+            default=None,
+            type=str,
+            metavar="NAME",
+            help="""Select the macro name for the assert block in CPU Bus interface logic"""
+        )
+
 
     def do_export(self, top_node: 'AddrmapNode', options: 'argparse.Namespace') -> None:
         cpuifs = self.get_cpuifs()
@@ -221,4 +229,5 @@ class Exporter(ExporterSubcommandPlugin):
             address_width=options.addr_width,
             default_reset_activelow=default_reset_activelow,
             default_reset_async=default_reset_async,
+            ext_strobe_assert_guard_macro=options.ext_strobe_assert_guard_macro,
         )

--- a/src/peakrdl_regblock/__peakrdl__.py
+++ b/src/peakrdl_regblock/__peakrdl__.py
@@ -159,6 +159,14 @@ class Exporter(ExporterSubcommandPlugin):
         )
 
         arg_group.add_argument(
+            "--rename-default-reset",
+            default="",
+            type=str,
+            metavar="RESET_NAME",
+            help="""Select a custom name for the reset signal"""
+        )
+
+        arg_group.add_argument(
             "--ext-strobe-assert-guard-macro",
             default=None,
             type=str,
@@ -229,5 +237,6 @@ class Exporter(ExporterSubcommandPlugin):
             address_width=options.addr_width,
             default_reset_activelow=default_reset_activelow,
             default_reset_async=default_reset_async,
+            rename_default_reset=options.rename_default_reset,
             ext_strobe_assert_guard_macro=options.ext_strobe_assert_guard_macro,
         )

--- a/src/peakrdl_regblock/dereferencer.py
+++ b/src/peakrdl_regblock/dereferencer.py
@@ -222,6 +222,8 @@ class Dereferencer:
 
     @property
     def default_resetsignal_name(self) -> str:
+        if self.ds.rename_default_reset:
+            return self.ds.rename_default_reset
         s = "rst"
         if self.ds.default_reset_async:
             s = f"a{s}"

--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -120,6 +120,8 @@ class RegblockExporter:
             If overriden to True, default reset is asynchronous instead of synchronous.
         ext_strobe_assert_guard_macro: str
             Sets the macro name for the assert block in the CPU Bus interface logic.
+        rename_default_reset: str
+            Select a new name for the reset signal. This parameter affects which name the reset signal has.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):
@@ -228,6 +230,7 @@ class DesignState:
         # Default reset type
         self.default_reset_activelow = kwargs.pop("default_reset_activelow", False) # type: bool
         self.default_reset_async = kwargs.pop("default_reset_async", False) # type: bool
+        self.rename_default_reset = kwargs.pop("rename_default_reset", '') # type: str
 
         #------------------------
         # Info about the design

--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -118,6 +118,8 @@ class RegblockExporter:
             If overriden to True, default reset is active-low instead of active-high.
         default_reset_async: bool
             If overriden to True, default reset is asynchronous instead of synchronous.
+        ext_strobe_assert_guard_macro: str
+            Sets the macro name for the assert block in the CPU Bus interface logic.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):
@@ -242,6 +244,7 @@ class DesignState:
 
         self.has_external_block = False
         self.has_external_addressable = False
+        self.ext_strobe_assert_guard_macro = kwargs.pop("ext_strobe_assert_guard_macro", False)
 
         self.has_paritycheck = False
 

--- a/src/peakrdl_regblock/readback/templates/readback.sv
+++ b/src/peakrdl_regblock/readback/templates/readback.sv
@@ -1,13 +1,13 @@
 {% if array_assignments is not none %}
 // Assign readback values to a flattened array
-logic [{{cpuif.data_width-1}}:0] readback_array[{{array_size}}];
+logic [{{cpuif.data_width-1}}:0] readback_array[{{array_size-1}}:0];
 {{array_assignments}}
 
 
 {%- if ds.retime_read_fanin %}
 
 // fanin stage
-logic [{{cpuif.data_width-1}}:0] readback_array_c[{{fanin_array_size}}];
+logic [{{cpuif.data_width-1}}:0] readback_array_c[{{fanin_array_size-1}}:0];
 for(genvar g=0; g<{{fanin_loop_iter}}; g++) begin
     always_comb begin
         automatic logic [{{cpuif.data_width-1}}:0] readback_data_var;
@@ -27,7 +27,7 @@ always_comb begin
 end
 {%- endif %}
 
-logic [{{cpuif.data_width-1}}:0] readback_array_r[{{fanin_array_size}}];
+logic [{{cpuif.data_width-1}}:0] readback_array_r[{{fanin_array_size-1}}:0];
 logic readback_done_r;
 always_ff {{get_always_ff_event(cpuif.reset)}} begin
     if({{get_resetsignal(cpuif.reset)}}) begin


### PR DESCRIPTION
# Description of change

fixed spyglass warning: Use [(N - 1):0] for multibit signal.
Added options for more flexible code generation.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x] If this change adds new features, I have added new unit tests that cover them.
