### PR TITLE
Add Addressmap block size to generated package

### DIFF
--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -20,6 +20,7 @@ from .write_buffering import WriteBuffering
 from .read_buffering import ReadBuffering
 from .external_acks import ExternalWriteAckGenerator, ExternalReadAckGenerator
 from .parity import ParityErrorReduceGenerator
+from .sv_int import SVInt
 
 if TYPE_CHECKING:
     from systemrdl.node import SignalNode
@@ -179,6 +180,7 @@ class RegblockExporter:
             "get_always_ff_event": self.dereferencer.get_always_ff_event,
             "ds": self.ds,
             "kwf": kwf,
+            "SVInt" : SVInt,
         }
 
         # Write out design

--- a/src/peakrdl_regblock/package_tmpl.sv
+++ b/src/peakrdl_regblock/package_tmpl.sv
@@ -5,7 +5,7 @@ package {{ds.package_name}};
 
     localparam {{ds.module_name.upper()}}_DATA_WIDTH = {{ds.cpuif_data_width}};
     localparam {{ds.module_name.upper()}}_MIN_ADDR_WIDTH = {{ds.addr_width}};
-    localparam {{ds.module_name.upper()}}_BYTES_SIZE = {{ds.top_node.size}};
+    localparam {{ds.module_name.upper()}}_SIZE = {{ds.top_node.size}};
 
     {{hwif.get_package_contents()|indent}}
 endpackage

--- a/src/peakrdl_regblock/package_tmpl.sv
+++ b/src/peakrdl_regblock/package_tmpl.sv
@@ -5,7 +5,7 @@ package {{ds.package_name}};
 
     localparam {{ds.module_name.upper()}}_DATA_WIDTH = {{ds.cpuif_data_width}};
     localparam {{ds.module_name.upper()}}_MIN_ADDR_WIDTH = {{ds.addr_width}};
-    localparam {{ds.module_name.upper()}}_SIZE = {{ds.top_node.size}};
+    localparam {{ds.module_name.upper()}}_SIZE = {{SVInt(ds.top_node.size)}};
 
     {{hwif.get_package_contents()|indent}}
 endpackage

--- a/src/peakrdl_regblock/package_tmpl.sv
+++ b/src/peakrdl_regblock/package_tmpl.sv
@@ -5,6 +5,7 @@ package {{ds.package_name}};
 
     localparam {{ds.module_name.upper()}}_DATA_WIDTH = {{ds.cpuif_data_width}};
     localparam {{ds.module_name.upper()}}_MIN_ADDR_WIDTH = {{ds.addr_width}};
+    localparam {{ds.module_name.upper()}}_SIZE = {{ds.top_node.size}};
 
     {{hwif.get_package_contents()|indent}}
 endpackage

--- a/src/peakrdl_regblock/package_tmpl.sv
+++ b/src/peakrdl_regblock/package_tmpl.sv
@@ -5,7 +5,7 @@ package {{ds.package_name}};
 
     localparam {{ds.module_name.upper()}}_DATA_WIDTH = {{ds.cpuif_data_width}};
     localparam {{ds.module_name.upper()}}_MIN_ADDR_WIDTH = {{ds.addr_width}};
-    localparam {{ds.module_name.upper()}}_SIZE = {{ds.top_node.size}};
+    localparam {{ds.module_name.upper()}}_BYTES_SIZE = {{ds.top_node.size}};
 
     {{hwif.get_package_contents()|indent}}
 endpackage

--- a/tests/test_map_size/regblock.rdl
+++ b/tests/test_map_size/regblock.rdl
@@ -1,0 +1,5 @@
+addrmap top {
+    reg {
+        field {} f1[32] = 0;
+    } my_reg;
+};

--- a/tests/test_map_size/tb_template.sv
+++ b/tests/test_map_size/tb_template.sv
@@ -1,0 +1,12 @@
+{% extends "lib/tb_base.sv" %}
+
+{% block seq %}
+    {% sv_line_anchor %}
+    ##1;
+    cb.rst <= '0;
+    ##1;
+
+    // check block size
+    assert(regblock_pkg::REGBLOCK_PKG_SIZE == {{exporter.ds.top_node.size}});
+
+{% endblock %}

--- a/tests/test_map_size/tb_template.sv
+++ b/tests/test_map_size/tb_template.sv
@@ -7,6 +7,6 @@
     ##1;
 
     // check block size
-    assert(regblock_pkg::REGBLOCK_PKG_BYTES_SIZE == {{exporter.ds.top_node.size}});
+    assert(regblock_pkg::REGBLOCK_SIZE == {{exporter.ds.top_node.size}});
 
 {% endblock %}

--- a/tests/test_map_size/tb_template.sv
+++ b/tests/test_map_size/tb_template.sv
@@ -7,6 +7,6 @@
     ##1;
 
     // check block size
-    assert(regblock_pkg::REGBLOCK_PKG_SIZE == {{exporter.ds.top_node.size}});
+    assert(regblock_pkg::REGBLOCK_PKG_BYTES_SIZE == {{exporter.ds.top_node.size}});
 
 {% endblock %}

--- a/tests/test_map_size/testcase.py
+++ b/tests/test_map_size/testcase.py
@@ -1,0 +1,5 @@
+from ..lib.sim_testcase import SimTestCase
+
+class Test(SimTestCase):
+    def test_dut(self):
+        self.run_test()


### PR DESCRIPTION
# Description of change

Hi, I'd like to propose a change that will include an address map's size in bytes as a localparam in the generated package file. Currently, the size of an address map can only be determined from the `MIN_ADDR_WIDTH` parameter and normally that is ok. However, if a user sets the cpu address width to something larger than needed, say for muxing a bus across multiple RDL (or other) maps in an MMIO space, then there's no way to determine the size of the map. If the address width is set to the width of the entire MMIO space, then the size of each map calculated would take up the entire mmio space rather than just the small part it uses. This makes it impossible to determine address offsets on maps in any automatic way. Including the total size of the map as a parameter would let a user implement back-to-back RDL maps within an MMIO space with some external bus muxing logic.

# Checklist

- [ x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x ] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x ] If this change adds new features, I have added new unit tests that cover them.
