### PR TITLE
Add parameters for address offsets to generated package

### DIFF
--- a/src/peakrdl_regblock/addr_decode.py
+++ b/src/peakrdl_regblock/addr_decode.py
@@ -251,11 +251,15 @@ class AddrOffsetGenerator(DecodeLogicGenerator):
 
 
     def enter_AddressableComponent(self, node: 'AddressableNode') -> Optional[WalkerAction]:
+        if node.external and not isinstance(node, RegNode):
+            # Is an external block
+            expr_width = self.addr_decode.exp.ds.addr_width
+            rhs = f"{self._get_address_offset_str(node)}"
+            s = f"localparam bit [{expr_width-1}:0] {self._get_address_offset_param_name(node)} = {rhs};"
+            self.add_content(s)
+            return WalkerAction.SkipDescendants
+
         return WalkerAction.Continue
-
-
-    def exit_AddressableComponent(self, node: 'AddressableNode') -> None:
-        return
 
 
     def enter_Reg(self, node: RegNode) -> None:
@@ -275,3 +279,7 @@ class AddrOffsetGenerator(DecodeLogicGenerator):
                 rhs = f"{self._get_address_offset_str(node, subword_offset=(i*subword_stride))}"
                 s = f"localparam bit [{expr_width-1}:0] {self._get_address_offset_param_name(node, subword_offset=(i*subword_stride))} = {rhs};"
                 self.add_content(s)
+
+
+    def exit_AddressableComponent(self, node: 'AddressableNode') -> None:
+        return

--- a/src/peakrdl_regblock/addr_decode.py
+++ b/src/peakrdl_regblock/addr_decode.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Union, List, Optional
+from re import sub as re_sub
 
 from systemrdl.node import FieldNode, RegNode
 from systemrdl.walker import WalkerAction
@@ -167,7 +168,8 @@ class DecodeLogicGenerator(RDLForLoopGenerator):
 
     def _get_address_offset_param_name(self, node: 'AddressableNode', subword_offset: int=0) -> str:
         a = f"{self.addr_decode.top_node.inst_name}"
-        a += f"__{get_indexed_path(self.addr_decode.top_node, node).split('[', 1)[0]}"
+        a += "__"
+        a += re_sub(r'\[.*?\]', '', get_indexed_path(self.addr_decode.top_node, node))
         if subword_offset != 0:
             a += f"_{subword_offset}"
         a += f"__offset"

--- a/src/peakrdl_regblock/package_tmpl.sv
+++ b/src/peakrdl_regblock/package_tmpl.sv
@@ -10,5 +10,7 @@ package {{ds.package_name}};
     {{hwif.get_extra_package_params()|indent}}
 
     {{hwif.get_package_contents()|indent}}
+
+    {{address_decode.get_address_offsets()|indent}}
 endpackage
 {# (eof newline anchor) #}


### PR DESCRIPTION
# Description of change

To provide some more clarity and accessibility to addresses from SystemVerilog, this change exposes the register address offsets (base address for arrays) of a regblock in the package as localparams. These parameters are then used directly as the offsets when generating the address decoding block.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x] If this change adds new features, I have added new unit tests that cover them.
