### PR TITLE
Add signed/fixedpoint properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,4 +83,5 @@ Links
     udps/read_buffering
     udps/write_buffering
     udps/extended_swacc
+    udps/signed
     udps/fixedpoint

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,3 +83,4 @@ Links
     udps/read_buffering
     udps/write_buffering
     udps/extended_swacc
+    udps/fixedpoint

--- a/docs/udps/fixedpoint.rst
+++ b/docs/udps/fixedpoint.rst
@@ -1,12 +1,12 @@
 .. _fixedpoint:
 
-Signed and Fixedpoint Fields
+Signed and Fixed-point Fields
 ============================
 
 SystemRDL does not natively provide a way to mark fields as signed or unsigned.
 The ``is_signed`` user-defined property fills this need. Similarly, the
 ``fracwidth`` and ``intwidth`` user-defined properties can be used to declare
-the fixedpoint representation of a field.
+the fixed-point representation of a field.
 
 For this SystemVerilog exporter, these properties only affect the signal type in
 the the ``hwif`` structs. There is no special handling in the internals of
@@ -14,7 +14,7 @@ the regblock.
 
 Properties
 ----------
-The behavior of signed and/or fixedpoint fields is defined using the following
+The behavior of signed and/or fixed-point fields is defined using the following
 three properties:
 
 .. literalinclude:: ../../hdl-src/regblock_udps.rdl
@@ -37,12 +37,12 @@ enabled by compiling the following file along with your design:
 .. describe:: intwidth
 
     *   The ``intwidth`` property defines the number of integer bits in the
-        fixedpoint representation (including the sign bit, if present).
+        fixed-point representation (including the sign bit, if present).
     *   If ``intwidth`` is defined for a field and ``is_signed`` is not,
         ``is_signed`` is inferred as false (unsigned).
-    *   If ``is_signed`` is true, the fixedpoint representation has a range from
+    *   If ``is_signed`` is true, the fixed-point representation has a range from
         :math:`-2^{\mathrm{intwidth}-1}` to :math:`2^{\mathrm{intwidth}-1} -2^{-\mathrm{fracwidth}}`.
-    *   If ``is_signed`` is false, the fixedpoint representation has a range from
+    *   If ``is_signed`` is false, the fixed-point representation has a range from
         :math:`0` to :math:`2^{\mathrm{intwidth}} - 2^{-\mathrm{fracwidth}}`.
     *   The type of the field in the ``hwif`` struct is
         ``logic (un)signed [intwidth-1:-fracwidth]``.
@@ -50,7 +50,7 @@ enabled by compiling the following file along with your design:
 .. describe:: fracwidth
 
     *   The ``fracwidth`` property defines the number of fractional bits in the
-        fixedpoint representation.
+        fixed-point representation.
     *   The weight of the least significant bit of the field is
         :math:`2^{-\mathrm{fracwidth}}`.
     *   If ``fracwidth`` is defined for a field and ``is_signed`` is not,

--- a/docs/udps/fixedpoint.rst
+++ b/docs/udps/fixedpoint.rst
@@ -1,0 +1,75 @@
+.. _fixedpoint:
+
+Signed and Fixedpoint Fields
+============================
+
+SystemRDL does not natively provide a way to mark fields as signed or unsigned.
+The ``is_signed`` user-defined property fills this need. Similarly, the
+``fracwidth`` and ``intwidth`` user-defined properties can be used to declare
+the fixedpoint representation of a field.
+
+For this SystemVerilog exporter, these properties only affect the signal type in
+the the ``hwif`` structs. There is no special handling in the internals of
+the regblock.
+
+Properties
+----------
+The behavior of signed and/or fixedpoint fields is defined using the following
+three properties:
+
+.. literalinclude:: ../../hdl-src/regblock_udps.rdl
+    :lines: 40-54
+
+These UDP definitions, along with others supported by PeakRDL-regblock can be
+enabled by compiling the following file along with your design:
+:download:`regblock_udps.rdl <../../hdl-src/regblock_udps.rdl>`.
+
+.. describe:: is_signed
+
+    *   Assigned value is a boolean.
+    *   If true, the hardware interface field will have the
+        ``logic signed [width-1:0]`` type.
+    *   If false, the hardware interface field will have the
+        ``logic unsigned [width-1:0]`` type.
+    *   If not defined for a field, the field will have the ``logic [width-1:0]``
+        type.
+
+.. describe:: intwidth
+
+    *   The ``intwidth`` property defines the number of integer bits in the
+        fixedpoint representation (including the sign bit, if present).
+    *   If ``intwidth`` is defined for a field and ``is_signed`` is not,
+        ``is_signed`` is inferred as false (unsigned).
+    *   If ``is_signed`` is true, the fixedpoint representation has a range from
+        :math:`-2^{\mathrm{intwidth}-1}` to :math:`2^{\mathrm{intwidth}-1} -2^{-\mathrm{fracwidth}}`.
+    *   If ``is_signed`` is false, the fixedpoint representation has a range from
+        :math:`0` to :math:`2^{\mathrm{intwidth}} - 2^{-\mathrm{fracwidth}}`.
+    *   The type of the field in the ``hwif`` struct is
+        ``logic (un)signed [intwidth-1:-fracwidth]``.
+
+.. describe:: fracwidth
+
+    *   The ``fracwidth`` property defines the number of fractional bits in the
+        fixedpoint representation.
+    *   The weight of the least significant bit of the field is
+        :math:`2^{-\mathrm{fracwidth}}`.
+    *   If ``fracwidth`` is defined for a field and ``is_signed`` is not,
+        ``is_signed`` is inferred as false (unsigned).
+    *   The type of the field in the ``hwif`` struct is
+        ``logic (un)signed [intwidth-1:-fracwidth]``.
+
+Other Rules
+^^^^^^^^^^^
+*   Only one of ``fracwidth`` or ``intwidth`` need be defined. The other is
+    inferred from the field bit width.
+*   The bit width of the field shall be equal to ``fracwidth`` + ``intwidth``.
+*   If both ``intwidth`` and ``fracwidth`` are defined for a field,  it is an
+    error if their sum does not equal the bit width of the field.
+*   Either ``fracwidth`` or ``intwidth`` can be a negative integer. Because
+    SystemRDL does not have a signed integer type, the only way to achieve
+    this is to define one of the widths as larger than the bit width of the
+    component so that the other width is inferred as a negative number.
+*   The properties defined above are mutually exclusive with the ``counter``
+    property (with the exception of ``is_signed=false``).
+*   The properties defined above are mutually exclusive with the ``encode``
+    property.

--- a/docs/udps/intro.rst
+++ b/docs/udps/intro.rst
@@ -66,7 +66,7 @@ To enable these UDPs, compile this RDL file prior to the rest of your design:
         - boolean
         - Defines the signedness of a field.
 
-          See: :ref:`fixedpoint`.
+          See: :ref:`signed`.
 
     *   - intwidth
         - field

--- a/docs/udps/intro.rst
+++ b/docs/udps/intro.rst
@@ -71,7 +71,7 @@ To enable these UDPs, compile this RDL file prior to the rest of your design:
     *   - intwidth
         - field
         - unsigned integer
-        - Defines the number of integer bits in the fixedpoint representation
+        - Defines the number of integer bits in the fixed-point representation
           of a field.
 
           See: :ref:`fixedpoint`.
@@ -79,7 +79,7 @@ To enable these UDPs, compile this RDL file prior to the rest of your design:
     *   - fracwidth
         - field
         - unsigned integer
-        - Defines the number of fractional bits in the fixedpoint representation
+        - Defines the number of fractional bits in the fixed-point representation
           of a field.
 
           See: :ref:`fixedpoint`.

--- a/docs/udps/intro.rst
+++ b/docs/udps/intro.rst
@@ -60,3 +60,26 @@ To enable these UDPs, compile this RDL file prior to the rest of your design:
         - Enables an output strobe that is asserted on sw writes.
 
           See: :ref:`extended_swacc`.
+
+    *   - is_signed
+        - field
+        - boolean
+        - Defines the signedness of a field.
+
+          See: :ref:`fixedpoint`.
+
+    *   - intwidth
+        - field
+        - unsigned integer
+        - Defines the number of integer bits in the fixedpoint representation
+          of a field.
+
+          See: :ref:`fixedpoint`.
+
+    *   - fracwidth
+        - field
+        - unsigned integer
+        - Defines the number of fractional bits in the fixedpoint representation
+          of a field.
+
+          See: :ref:`fixedpoint`.

--- a/docs/udps/signed.rst
+++ b/docs/udps/signed.rst
@@ -1,0 +1,74 @@
+.. _signed:
+
+Signed Fields
+=============
+
+SystemRDL does not natively provide a way to mark fields as signed or unsigned.
+The ``is_signed`` user-defined property fills this need.
+
+For this SystemVerilog exporter, marking a field as signed only affects the
+signal type in the ``hwif`` structs. There is no special handling in the internals
+of the regblock.
+
+Properties
+----------
+A field can be marked as signed using the following user-defined property:
+
+.. literalinclude:: ../../hdl-src/regblock_udps.rdl
+    :lines: 40-44
+
+This UDP definition, along with others supported by PeakRDL-regblock, can be
+enabled by compiling the following file along with your design:
+:download:`regblock_udps.rdl <../../hdl-src/regblock_udps.rdl>`.
+
+.. describe:: is_signed
+
+    *   Assigned value is a boolean.
+    *   If true, the hardware interface field will have the type
+        ``logic signed [width-1:0]``.
+    *   If false or not defined for a field, the hardware interface field will
+        have the type ``logic [width-1:0]``, which is unsigned by definition.
+
+Other Rules
+^^^^^^^^^^^
+
+*   ``is_signed=true`` is mutually exclusive with the ``counter`` property.
+*   ``is_signed=true`` is mutually exclusive with the ``encode`` property.
+
+Examples
+--------
+Below are some examples of fields with different signedness.
+
+Signed Fields
+^^^^^^^^^^^^^
+.. code-block:: systemrdl
+    :emphasize-lines: 3, 8
+
+    field {
+        sw=rw; hw=r;
+        is_signed;
+    } signed_num[63:0] = 0;
+
+    field {
+        sw=r; hw=w;
+        is_signed = true;
+    } another_signed_num[19:0] = 20'hFFFFF; // -1
+
+SystemRDL's own integer type is always unsigned. In order to specify a negative
+reset value, the two's complement value must be used as shown in the second
+example above.
+
+Unsigned Fields
+^^^^^^^^^^^^^^^
+.. code-block:: systemrdl
+    :emphasize-lines: 3, 8
+
+    field {
+        sw=rw; hw=r;
+        // fields are unsigned by default
+    } unsigned_num[63:0] = 0;
+
+    field {
+        sw=r; hw=w;
+        is_signed = false;
+    } another_unsigned_num[19:0] = 0;

--- a/hdl-src/regblock_udps.rdl
+++ b/hdl-src/regblock_udps.rdl
@@ -36,3 +36,19 @@ property wr_swacc {
     component = field;
     type = boolean;
 };
+
+property is_signed {
+    type = bool;
+    component = field | signal;
+    default = true;
+};
+
+property intwidth {
+    type = longint unsigned;
+    component = field | signal;
+};
+
+property fracwidth {
+    type = longint unsigned;
+    component = field | signal;
+};

--- a/hdl-src/regblock_udps.rdl
+++ b/hdl-src/regblock_udps.rdl
@@ -39,16 +39,16 @@ property wr_swacc {
 
 property is_signed {
     type = boolean;
-    component = field | signal;
+    component = field;
     default = true;
 };
 
 property intwidth {
     type = longint unsigned;
-    component = field | signal;
+    component = field;
 };
 
 property fracwidth {
     type = longint unsigned;
-    component = field | signal;
+    component = field;
 };

--- a/hdl-src/regblock_udps.rdl
+++ b/hdl-src/regblock_udps.rdl
@@ -38,7 +38,7 @@ property wr_swacc {
 };
 
 property is_signed {
-    type = bool;
+    type = boolean;
     component = field | signal;
     default = true;
 };

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -35,7 +35,7 @@ class HWIFStructGenerator(RDLFlatStructGenerator):
         super().pop_struct()
         self.hwif_report_stack.pop()
 
-    def add_member(self, name: str, width: int = 1, *, lsb: int = 0, signed: Optional[bool] = None) -> None: # type: ignore # pylint: disable=arguments-differ
+    def add_member(self, name: str, width: int = 1, *, lsb: int = 0, signed: bool = False) -> None: # type: ignore # pylint: disable=arguments-differ
         super().add_member(name, width, lsb=lsb, signed=signed)
 
         if width > 1 or lsb != 0:

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -145,7 +145,7 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
         # Provide input to field's next value if it is writable by hw, and it
         # was not overridden by the 'next' property
         if node.is_hw_writable and node.get_property('next') is None:
-            # Get the field's LSB index (can be nonzero for fixedpoint values)
+            # Get the field's LSB index (can be nonzero for fixed-point values)
             fracwidth = node.get_property("fracwidth")
             lsb = 0 if fracwidth is None else -fracwidth
 
@@ -278,7 +278,7 @@ class OutputStructGenerator_Hier(HWIFStructGenerator):
 
         # Expose field's value if it is readable by hw
         if node.is_hw_readable:
-            # Get the node's LSB index (can be nonzero for fixedpoint values)
+            # Get the node's LSB index (can be nonzero for fixed-point values)
             fracwidth = node.get_property("fracwidth")
             lsb = 0 if fracwidth is None else -fracwidth
 

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -146,13 +146,13 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
         type_name = self.get_typdef_name(node)
         self.push_struct(type_name, kwf(node.inst_name))
 
-        # Get the node's LSB index (can be nonzero for fixedpoint values)
-        fracwidth = node.get_property("fracwidth")
-        lsb = 0 if fracwidth is None else -fracwidth
-
         # Provide input to field's next value if it is writable by hw, and it
         # was not overridden by the 'next' property
         if node.is_hw_writable and node.get_property('next') is None:
+            # Get the field's LSB index (can be nonzero for fixedpoint values)
+            fracwidth = node.get_property("fracwidth")
+            lsb = 0 if fracwidth is None else -fracwidth
+
             self.add_member("next", node.width, lsb)
 
         # Generate implied inputs
@@ -171,7 +171,7 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
             width = node.get_property('incrwidth')
             if width:
                 # Implies a corresponding incrvalue input
-                self.add_member('incrvalue', width, lsb)
+                self.add_member('incrvalue', width)
 
         if node.is_down_counter:
             if not node.get_property('decr'):
@@ -182,7 +182,7 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
             width = node.get_property('decrwidth')
             if width:
                 # Implies a corresponding decrvalue input
-                self.add_member('decrvalue', width, lsb)
+                self.add_member('decrvalue', width)
 
     def exit_Field(self, node: 'FieldNode') -> None:
         self.pop_struct()

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -35,8 +35,8 @@ class HWIFStructGenerator(RDLFlatStructGenerator):
         super().pop_struct()
         self.hwif_report_stack.pop()
 
-    def add_member(self, name: str, width: int = 1, lsb: int = 0) -> None: # type: ignore # pylint: disable=arguments-differ
-        super().add_member(name, width, lsb=lsb)
+    def add_member(self, name: str, width: int = 1, lsb: int = 0, signed: Optional[bool] = None) -> None: # type: ignore # pylint: disable=arguments-differ
+        super().add_member(name, width, lsb=lsb, signed=signed)
 
         if width > 1:
             suffix = f"[{lsb+width-1}:{lsb}]"
@@ -70,7 +70,10 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
             fracwidth = node.get_property("fracwidth")
             lsb = 0 if fracwidth is None else -fracwidth
 
-            self.add_member(kwf(node.inst_name), node.width, lsb)
+            # get the signedness of the signal
+            signed = node.get_property("is_signed")
+
+            self.add_member(kwf(node.inst_name), node.width, lsb, signed)
 
     def _add_external_block_members(self, node: 'AddressableNode') -> None:
         self.add_member("rd_ack")
@@ -153,7 +156,10 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
             fracwidth = node.get_property("fracwidth")
             lsb = 0 if fracwidth is None else -fracwidth
 
-            self.add_member("next", node.width, lsb)
+            # get the signedness of the field
+            signed = node.get_property("is_signed")
+
+            self.add_member("next", node.width, lsb, signed)
 
         # Generate implied inputs
         for prop_name in ["we", "wel", "swwe", "swwel", "hwclr", "hwset"]:
@@ -283,7 +289,10 @@ class OutputStructGenerator_Hier(HWIFStructGenerator):
             fracwidth = node.get_property("fracwidth")
             lsb = 0 if fracwidth is None else -fracwidth
 
-            self.add_member("value", node.width, lsb)
+            # get the signedness of the field
+            signed = node.get_property("is_signed")
+
+            self.add_member("value", node.width, lsb, signed)
 
         # Generate output bit signals enabled via property
         for prop_name in ["anded", "ored", "xored", "swmod", "swacc", "overflow", "underflow", "rd_swacc", "wr_swacc"]:

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -38,7 +38,7 @@ class HWIFStructGenerator(RDLFlatStructGenerator):
     def add_member(self, name: str, width: int = 1, lsb: int = 0, signed: Optional[bool] = None) -> None: # type: ignore # pylint: disable=arguments-differ
         super().add_member(name, width, lsb=lsb, signed=signed)
 
-        if width > 1:
+        if width > 1 or lsb != 0:
             suffix = f"[{lsb+width-1}:{lsb}]"
         else:
             suffix = ""

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -66,14 +66,7 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
         # only emit the signal if design scanner detected it is actually being used
         path = node.get_path()
         if path in self.hwif.ds.in_hier_signal_paths:
-            # Get the node's LSB index (can be nonzero for fixedpoint values)
-            fracwidth = node.get_property("fracwidth")
-            lsb = 0 if fracwidth is None else -fracwidth
-
-            # get the signedness of the signal
-            signed = node.get_property("is_signed")
-
-            self.add_member(kwf(node.inst_name), node.width, lsb, signed)
+            self.add_member(kwf(node.inst_name), node.width)
 
     def _add_external_block_members(self, node: 'AddressableNode') -> None:
         self.add_member("rd_ack")

--- a/src/peakrdl_regblock/hwif/generators.py
+++ b/src/peakrdl_regblock/hwif/generators.py
@@ -35,7 +35,7 @@ class HWIFStructGenerator(RDLFlatStructGenerator):
         super().pop_struct()
         self.hwif_report_stack.pop()
 
-    def add_member(self, name: str, width: int = 1, lsb: int = 0, signed: Optional[bool] = None) -> None: # type: ignore # pylint: disable=arguments-differ
+    def add_member(self, name: str, width: int = 1, *, lsb: int = 0, signed: Optional[bool] = None) -> None: # type: ignore # pylint: disable=arguments-differ
         super().add_member(name, width, lsb=lsb, signed=signed)
 
         if width > 1 or lsb != 0:
@@ -152,7 +152,7 @@ class InputStructGenerator_Hier(HWIFStructGenerator):
             # get the signedness of the field
             signed = node.get_property("is_signed")
 
-            self.add_member("next", node.width, lsb, signed)
+            self.add_member("next", node.width, lsb=lsb, signed=signed)
 
         # Generate implied inputs
         for prop_name in ["we", "wel", "swwe", "swwel", "hwclr", "hwset"]:
@@ -285,7 +285,7 @@ class OutputStructGenerator_Hier(HWIFStructGenerator):
             # get the signedness of the field
             signed = node.get_property("is_signed")
 
-            self.add_member("value", node.width, lsb, signed)
+            self.add_member("value", node.width, lsb=lsb, signed=signed)
 
         # Generate output bit signals enabled via property
         for prop_name in ["anded", "ored", "xored", "swmod", "swacc", "overflow", "underflow", "rd_swacc", "wr_swacc"]:

--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -88,7 +88,7 @@ class StructGenerator:
         self._struct_stack.append(s)
 
 
-    def add_member(self, name: str, width: int = 1, array_dimensions: Optional[List[int]] = None) -> None:
+    def add_member(self, name: str, width: int = 1, array_dimensions: Optional[List[int]] = None, lsb: int = 0) -> None:
         if array_dimensions:
             suffix = "[" + "][".join((str(n) for n in array_dimensions)) + "]"
         else:
@@ -97,7 +97,7 @@ class StructGenerator:
         if width == 1:
             m = f"logic {name}{suffix};"
         else:
-            m = f"logic [{width-1}:0] {name}{suffix};"
+            m = f"logic [{lsb+width-1}:{lsb}] {name}{suffix};"
         self.current_struct.children.append(m)
 
 

--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -95,19 +95,18 @@ class StructGenerator:
             array_dimensions: Optional[List[int]] = None,
             *,
             lsb: int = 0,
-            signed: Optional[bool] = None,
+            signed: bool = False,
     ) -> None:
         if array_dimensions:
             suffix = "[" + "][".join((str(n) for n in array_dimensions)) + "]"
         else:
             suffix = ""
 
-        if signed is None:
-            sign = ""
-        elif signed:
+        if signed:
             sign = "signed "
         else:
-            sign = "unsigned "
+            # the default 'logic' type is unsigned per SV LRM 6.11.3
+            sign = ""
 
         if width == 1 and lsb == 0:
             m = f"logic {sign}{name}{suffix};"

--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -88,16 +88,30 @@ class StructGenerator:
         self._struct_stack.append(s)
 
 
-    def add_member(self, name: str, width: int = 1, array_dimensions: Optional[List[int]] = None, lsb: int = 0) -> None:
+    def add_member(
+            self,
+            name: str,
+            width: int = 1,
+            array_dimensions: Optional[List[int]] = None,
+            lsb: int = 0,
+            signed: Optional[bool] = None,
+    ) -> None:
         if array_dimensions:
             suffix = "[" + "][".join((str(n) for n in array_dimensions)) + "]"
         else:
             suffix = ""
 
-        if width == 1:
-            m = f"logic {name}{suffix};"
+        if signed is None:
+            sign = ""
+        elif signed:
+            sign = "signed "
         else:
-            m = f"logic [{lsb+width-1}:{lsb}] {name}{suffix};"
+            sign = "unsigned "
+
+        if width == 1:
+            m = f"logic {sign}{name}{suffix};"
+        else:
+            m = f"logic {sign}[{lsb+width-1}:{lsb}] {name}{suffix};"
         self.current_struct.children.append(m)
 
 

--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -108,7 +108,7 @@ class StructGenerator:
         else:
             sign = "unsigned "
 
-        if width == 1:
+        if width == 1 and lsb == 0:
             m = f"logic {sign}{name}{suffix};"
         else:
             m = f"logic {sign}[{lsb+width-1}:{lsb}] {name}{suffix};"

--- a/src/peakrdl_regblock/struct_generator.py
+++ b/src/peakrdl_regblock/struct_generator.py
@@ -93,6 +93,7 @@ class StructGenerator:
             name: str,
             width: int = 1,
             array_dimensions: Optional[List[int]] = None,
+            *,
             lsb: int = 0,
             signed: Optional[bool] = None,
     ) -> None:

--- a/src/peakrdl_regblock/udps/__init__.py
+++ b/src/peakrdl_regblock/udps/__init__.py
@@ -1,6 +1,7 @@
 from .rw_buffering import BufferWrites, WBufferTrigger
 from .rw_buffering import BufferReads, RBufferTrigger
 from .extended_swacc import ReadSwacc, WriteSwacc
+from .fixedpoint import IntWidth, FracWidth, IsSigned
 
 ALL_UDPS = [
     BufferWrites,
@@ -9,4 +10,7 @@ ALL_UDPS = [
     RBufferTrigger,
     ReadSwacc,
     WriteSwacc,
+    IntWidth,
+    FracWidth,
+    IsSigned,
 ]

--- a/src/peakrdl_regblock/udps/__init__.py
+++ b/src/peakrdl_regblock/udps/__init__.py
@@ -1,7 +1,8 @@
 from .rw_buffering import BufferWrites, WBufferTrigger
 from .rw_buffering import BufferReads, RBufferTrigger
 from .extended_swacc import ReadSwacc, WriteSwacc
-from .fixedpoint import IntWidth, FracWidth, IsSigned
+from .fixedpoint import IntWidth, FracWidth
+from .signed import IsSigned
 
 ALL_UDPS = [
     BufferWrites,

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -16,27 +16,28 @@ class FixedpointWidth(UDPDefinition):
         fracwidth = node.get_property("fracwidth")
         assert intwidth is not None
         assert fracwidth is not None
+        prop_ref = node.inst.property_src_ref.get(self.name)
 
         # incompatible with "counter" fields
         if node.get_property("counter"):
             self.msg.error(
-                f"{type(node.inst).__name__.lower()} '{node.inst_name}': fixedpoint values"
-                f" are not supported for counter fields."
+                "Fixedpoint representations are not supported for counter fields.",
+                prop_ref
             )
 
         # incompatible with "encode" fields
         if node.get_property("encode") is not None:
             self.msg.error(
-                f"{type(node.inst).__name__.lower()} '{node.inst_name}': fixedpoint values"
-                f" are not supported for fields encoded as an enum."
+                "Fixedpoint representations are not supported for fields encoded as an enum.",
+                prop_ref
             )
 
         # ensure node width = fracwidth + intwidth
         if intwidth + fracwidth != node.width:
             self.msg.error(
-                f"{type(node.inst).__name__.lower()} '{node.inst_name}' number of"
-                f" integer bits ({intwidth}) plus number of fractional bits ({fracwidth})"
-                f" must be equal to the width of the component ({node.width})."
+                f"Number of integer bits ({intwidth}) plus number of fractional bits ({fracwidth})"
+                f" must be equal to the width of the component ({node.width}).",
+                prop_ref
             )
 
 
@@ -75,18 +76,18 @@ class IsSigned(UDPDefinition):
     default_assignment = True
 
     def validate(self, node: "Node", value: Any) -> None:
-        # incompatible with "counter" fields
-        if node.get_property("counter"):
+        # "counter" fields can not be signed
+        if value and node.get_property("counter"):
             self.msg.error(
-                f"{type(node.inst).__name__.lower()} '{node.inst_name}': is_signed property"
-                f" is not supported for counter fields."
+                "The property is_signed=true is not supported for counter fields.",
+                node.inst.property_src_ref["is_signed"]
             )
 
         # incompatible with "encode" fields
         if node.get_property("encode") is not None:
             self.msg.error(
-                f"{type(node.inst).__name__.lower()} '{node.inst_name}': is_signed property"
-                f" is not supported for fields encoded as an enum."
+                "The is_signed property is not supported for fields encoded as an enum.",
+                node.inst.property_src_ref["is_signed"]
             )
 
     def get_unassigned_default(self, node: "Node") -> Any:

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -1,16 +1,16 @@
 from typing import Any
 
-from systemrdl.component import Field, Signal
-from systemrdl.node import Node, VectorNode
+from systemrdl.component import Field
+from systemrdl.node import Node, FieldNode
 from systemrdl.udp import UDPDefinition
 
 
 class FixedpointWidth(UDPDefinition):
-    valid_components = {Field, Signal}
+    valid_components = {Field}
     valid_type = int
 
     def validate(self, node: "Node", value: Any) -> None:
-        assert isinstance(node, VectorNode)
+        assert isinstance(node, FieldNode)
 
         intwidth = node.get_property("intwidth")
         fracwidth = node.get_property("fracwidth")
@@ -48,7 +48,7 @@ class IntWidth(FixedpointWidth):
         # if 'fracwidth' is defined, 'intwidth' is inferred from the node width
         fracwidth = node.get_property("fracwidth", default=None)
         if fracwidth is not None:
-            assert isinstance(node, VectorNode)
+            assert isinstance(node, FieldNode)
             return node.width - fracwidth
         else:
             # not a fixedpoint number
@@ -62,7 +62,7 @@ class FracWidth(FixedpointWidth):
         # if 'intwidth' is defined, 'fracwidth' is inferred from the node width
         intwidth = node.get_property("intwidth", default=None)
         if intwidth is not None:
-            assert isinstance(node, VectorNode)
+            assert isinstance(node, FieldNode)
             return node.width - intwidth
         else:
             # not a fixedpoint number
@@ -71,7 +71,7 @@ class FracWidth(FixedpointWidth):
 
 class IsSigned(UDPDefinition):
     name = "is_signed"
-    valid_components = {Field, Signal}
+    valid_components = {Field}
     valid_type = bool
     default_assignment = True
 

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -5,7 +5,7 @@ from systemrdl.node import Node, FieldNode
 from systemrdl.udp import UDPDefinition
 
 
-class FixedpointWidth(UDPDefinition):
+class _FixedpointWidth(UDPDefinition):
     valid_components = {Field}
     valid_type = int
 
@@ -41,28 +41,32 @@ class FixedpointWidth(UDPDefinition):
             )
 
 
-class IntWidth(FixedpointWidth):
+class IntWidth(_FixedpointWidth):
     name = "intwidth"
 
     def get_unassigned_default(self, node: "Node") -> Any:
-        # if 'fracwidth' is defined, 'intwidth' is inferred from the node width
+        """
+        If 'fracwidth' is defined, 'intwidth' is inferred from the node width.
+        """
+        assert isinstance(node, FieldNode)
         fracwidth = node.get_property("fracwidth", default=None)
         if fracwidth is not None:
-            assert isinstance(node, FieldNode)
             return node.width - fracwidth
         else:
             # not a fixed-point number
             return None
 
 
-class FracWidth(FixedpointWidth):
+class FracWidth(_FixedpointWidth):
     name = "fracwidth"
 
     def get_unassigned_default(self, node: "Node") -> Any:
-        # if 'intwidth' is defined, 'fracwidth' is inferred from the node width
+        """
+        If 'intwidth' is defined, 'fracwidth' is inferred from the node width.
+        """
+        assert isinstance(node, FieldNode)
         intwidth = node.get_property("intwidth", default=None)
         if intwidth is not None:
-            assert isinstance(node, FieldNode)
             return node.width - intwidth
         else:
             # not a fixed-point number

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -21,14 +21,14 @@ class FixedpointWidth(UDPDefinition):
         # incompatible with "counter" fields
         if node.get_property("counter"):
             self.msg.error(
-                "Fixedpoint representations are not supported for counter fields.",
+                "Fixed-point representations are not supported for counter fields.",
                 prop_ref
             )
 
         # incompatible with "encode" fields
         if node.get_property("encode") is not None:
             self.msg.error(
-                "Fixedpoint representations are not supported for fields encoded as an enum.",
+                "Fixed-point representations are not supported for fields encoded as an enum.",
                 prop_ref
             )
 
@@ -51,7 +51,7 @@ class IntWidth(FixedpointWidth):
             assert isinstance(node, FieldNode)
             return node.width - fracwidth
         else:
-            # not a fixedpoint number
+            # not a fixed-point number
             return None
 
 
@@ -65,7 +65,7 @@ class FracWidth(FixedpointWidth):
             assert isinstance(node, FieldNode)
             return node.width - intwidth
         else:
-            # not a fixedpoint number
+            # not a fixed-point number
             return None
 
 
@@ -93,8 +93,8 @@ class IsSigned(UDPDefinition):
     def get_unassigned_default(self, node: "Node") -> Any:
         intwidth = node.get_property("intwidth")
         if intwidth is not None:
-            # it's a fixedpoint number, default to unsigned
+            # it's a fixed-point number, default to unsigned
             return False
         else:
-            # not a fixedpoint number
+            # not a fixed-point number
             return None

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -84,9 +84,9 @@ class IsSigned(UDPDefinition):
             )
 
         # incompatible with "encode" fields
-        if node.get_property("encode") is not None:
+        if value and node.get_property("encode") is not None:
             self.msg.error(
-                "The is_signed property is not supported for fields encoded as an enum.",
+                "The property is_signed=true is not supported for fields encoded as an enum.",
                 node.inst.property_src_ref["is_signed"]
             )
 

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -58,6 +58,7 @@ class IsSigned(UDPDefinition):
     name = "is_signed"
     valid_components = {Field, Signal}
     valid_type = bool
+    default_assignment = True
 
     def get_unassigned_default(self, node: "Node") -> Any:
         intwidth = node.get_property("intwidth")

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -17,6 +17,20 @@ class FixedpointWidth(UDPDefinition):
         assert intwidth is not None
         assert fracwidth is not None
 
+        # incompatible with "counter" fields
+        if node.get_property("counter"):
+            self.msg.error(
+                f"{type(node.inst).__name__.lower()} '{node.inst_name}': fixedpoint values"
+                f" are not supported for counter fields."
+            )
+
+        # incompatible with "encode" fields
+        if node.get_property("encode") is not None:
+            self.msg.error(
+                f"{type(node.inst).__name__.lower()} '{node.inst_name}': fixedpoint values"
+                f" are not supported for fields encoded as an enum."
+            )
+
         # ensure node width = fracwidth + intwidth
         if intwidth + fracwidth != node.width:
             self.msg.error(
@@ -59,6 +73,21 @@ class IsSigned(UDPDefinition):
     valid_components = {Field, Signal}
     valid_type = bool
     default_assignment = True
+
+    def validate(self, node: "Node", value: Any) -> None:
+        # incompatible with "counter" fields
+        if node.get_property("counter"):
+            self.msg.error(
+                f"{type(node.inst).__name__.lower()} '{node.inst_name}': is_signed property"
+                f" is not supported for counter fields."
+            )
+
+        # incompatible with "encode" fields
+        if node.get_property("encode") is not None:
+            self.msg.error(
+                f"{type(node.inst).__name__.lower()} '{node.inst_name}': is_signed property"
+                f" is not supported for fields encoded as an enum."
+            )
 
     def get_unassigned_default(self, node: "Node") -> Any:
         intwidth = node.get_property("intwidth")

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -67,29 +67,3 @@ class FracWidth(FixedpointWidth):
         else:
             # not a fixed-point number
             return None
-
-
-class IsSigned(UDPDefinition):
-    name = "is_signed"
-    valid_components = {Field}
-    valid_type = bool
-    default_assignment = True
-
-    def validate(self, node: "Node", value: Any) -> None:
-        # "counter" fields can not be signed
-        if value and node.get_property("counter"):
-            self.msg.error(
-                "The property is_signed=true is not supported for counter fields.",
-                node.inst.property_src_ref["is_signed"]
-            )
-
-        # incompatible with "encode" fields
-        if value and node.get_property("encode") is not None:
-            self.msg.error(
-                "The property is_signed=true is not supported for fields encoded as an enum.",
-                node.inst.property_src_ref["is_signed"]
-            )
-
-    def get_unassigned_default(self, node: "Node") -> Any:
-        # unsigned if not specified
-        return False

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from systemrdl.component import Field, Signal
+from systemrdl.node import Node, VectorNode
+from systemrdl.udp import UDPDefinition
+
+
+class FixedpointWidth(UDPDefinition):
+    valid_components = {Field, Signal}
+    valid_type = int
+
+    def validate(self, node: "Node", value: Any) -> None:
+        assert isinstance(node, VectorNode)
+
+        intwidth = node.get_property("intwidth")
+        fracwidth = node.get_property("fracwidth")
+        assert intwidth is not None
+        assert fracwidth is not None
+
+        # ensure node width = fracwidth + intwidth
+        if intwidth + fracwidth != node.width:
+            self.msg.error(
+                f"{type(node.inst).__name__.lower()} '{node.inst_name}' number of"
+                f" integer bits ({intwidth}) plus number of fractional bits ({fracwidth})"
+                f" must be equal to the width of the component ({node.width})."
+            )
+
+
+class IntWidth(FixedpointWidth):
+    name = "intwidth"
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        # if 'fracwidth' is defined, 'intwidth' is inferred from the node width
+        fracwidth = node.get_property("fracwidth", default=None)
+        if fracwidth is not None:
+            assert isinstance(node, VectorNode)
+            return node.width - fracwidth
+        else:
+            # not a fixedpoint number
+            return None
+
+
+class FracWidth(FixedpointWidth):
+    name = "fracwidth"
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        # if 'intwidth' is defined, 'fracwidth' is inferred from the node width
+        intwidth = node.get_property("intwidth", default=None)
+        if intwidth is not None:
+            assert isinstance(node, VectorNode)
+            return node.width - intwidth
+        else:
+            # not a fixedpoint number
+            return None
+
+
+class IsSigned(UDPDefinition):
+    name = "is_signed"
+    valid_components = {Field, Signal}
+    valid_type = bool
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        intwidth = node.get_property("intwidth")
+        if intwidth is not None:
+            # it's a fixedpoint number, default to unsigned
+            return False
+        else:
+            # not a fixedpoint number
+            return None

--- a/src/peakrdl_regblock/udps/fixedpoint.py
+++ b/src/peakrdl_regblock/udps/fixedpoint.py
@@ -91,10 +91,5 @@ class IsSigned(UDPDefinition):
             )
 
     def get_unassigned_default(self, node: "Node") -> Any:
-        intwidth = node.get_property("intwidth")
-        if intwidth is not None:
-            # it's a fixed-point number, default to unsigned
-            return False
-        else:
-            # not a fixed-point number
-            return None
+        # unsigned if not specified
+        return False

--- a/src/peakrdl_regblock/udps/signed.py
+++ b/src/peakrdl_regblock/udps/signed.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from systemrdl.component import Field
+from systemrdl.node import Node
+from systemrdl.udp import UDPDefinition
+
+
+class IsSigned(UDPDefinition):
+    name = "is_signed"
+    valid_components = {Field}
+    valid_type = bool
+    default_assignment = True
+
+    def validate(self, node: "Node", value: Any) -> None:
+        # "counter" fields can not be signed
+        if value and node.get_property("counter"):
+            self.msg.error(
+                "The property is_signed=true is not supported for counter fields.",
+                node.inst.property_src_ref["is_signed"]
+            )
+
+        # incompatible with "encode" fields
+        if value and node.get_property("encode") is not None:
+            self.msg.error(
+                "The property is_signed=true is not supported for fields encoded as an enum.",
+                node.inst.property_src_ref["is_signed"]
+            )
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        # unsigned if not specified
+        return False

--- a/src/peakrdl_regblock/udps/signed.py
+++ b/src/peakrdl_regblock/udps/signed.py
@@ -27,5 +27,7 @@ class IsSigned(UDPDefinition):
             )
 
     def get_unassigned_default(self, node: "Node") -> Any:
-        # unsigned if not specified
+        """
+        Unsigned by default if not specified.
+        """
         return False

--- a/tests/test_fixedpoint/regblock.rdl
+++ b/tests/test_fixedpoint/regblock.rdl
@@ -1,0 +1,34 @@
+addrmap top {
+    default accesswidth = 64;
+    default regwidth = 64;
+    reg {
+        field {
+            sw = rw; hw = r;
+            intwidth = 8;
+            fracwidth = 8;
+        } f_Q8_8[16] = 0;
+        field {
+            sw = r; hw = w;
+            intwidth = 32;
+        } f_Q32_n8[24];
+        field {
+            sw = rw; hw = r;
+            fracwidth = 32;
+            is_signed;
+        } f_SQn8_32[24] = 0;
+    } r1 @ 0x0;
+
+    reg {
+        field {
+            sw = r; hw = w;
+            is_signed;
+        } f_signed[16];
+        field {
+            sw = rw; hw = r;
+            is_signed = false;
+        } f_unsigned[16] = 0;
+        field {
+            sw = r; hw = w;
+        } f_no_sign[16];
+    } r2 @ 0x8;
+};

--- a/tests/test_fixedpoint/regblock.rdl
+++ b/tests/test_fixedpoint/regblock.rdl
@@ -10,12 +10,17 @@ addrmap top {
         field {
             sw = r; hw = w;
             intwidth = 32;
-        } f_Q32_n8[24];
+        } f_Q32_n12[20];
         field {
             sw = rw; hw = r;
             fracwidth = 32;
             is_signed;
         } f_SQn8_32[24] = 0;
+        field {
+            sw = rw; hw = r;
+            fracwidth = 7;
+            is_signed;
+        } f_SQn6_7 = 0;
     } r1 @ 0x0;
 
     reg {

--- a/tests/test_fixedpoint/tb_template.sv
+++ b/tests/test_fixedpoint/tb_template.sv
@@ -7,7 +7,7 @@
     ##1;
 
     // set all fields to all 1s
-    cb.hwif_in.r1.f_Q32_n8.next <= '1;
+    cb.hwif_in.r1.f_Q32_n12.next <= '1;
     cb.hwif_in.r2.f_signed.next <= '1;
     cb.hwif_in.r2.f_no_sign.next <= '1;
     cpuif.write('h0, 64'hFFFF_FFFF_FFFF_FFFF);
@@ -22,13 +22,13 @@
     // verfy unsigned
     assert(cb.hwif_out.r1.f_Q8_8.value > 0);
 
-    // Q32.-8
+    // Q32.-12
     // verify bit range
-    assert(cb.hwif_in.r1.f_Q32_n8.next[31:8] == '1);
+    assert(cb.hwif_in.r1.f_Q32_n12.next[31:12] == '1);
     // verify bit width
-    assert($size(cb.hwif_in.r1.f_Q32_n8.next) == 24);
+    assert($size(cb.hwif_in.r1.f_Q32_n12.next) == 20);
     // verify unsigned
-    assert(cb.hwif_in.r1.f_Q32_n8.next > 0);
+    assert(cb.hwif_in.r1.f_Q32_n12.next > 0);
 
     // SQ-8.32
     // verify bit range
@@ -37,6 +37,14 @@
     assert($size(cb.hwif_out.r1.f_SQn8_32.value) == 24);
     // verify signed
     assert(cb.hwif_out.r1.f_SQn8_32.value < 0);
+
+    // SQ-6.7
+    // verify bit range
+    assert(cb.hwif_out.r1.f_SQn6_7.value[-7:-7] == '1);
+    // verify bit width
+    assert($size(cb.hwif_out.r1.f_SQn6_7.value) == 1);
+    // verify signed
+    assert(cb.hwif_out.r1.f_SQn6_7.value < 0);
 
     // 16-bit signed integer
     // verify bit range
@@ -63,7 +71,7 @@
     assert(cb.hwif_in.r2.f_no_sign.next > 0);
 
     // verify readback
-    cpuif.assert_read('h0, 64'hFFFF_FFFF_FFFF_FFFF);
+    cpuif.assert_read('h0, 64'h1FFF_FFFF_FFFF_FFFF);
     cpuif.assert_read('h8, 64'h0000_FFFF_FFFF_FFFF);
 
 {% endblock %}

--- a/tests/test_fixedpoint/tb_template.sv
+++ b/tests/test_fixedpoint/tb_template.sv
@@ -1,0 +1,69 @@
+{% extends "lib/tb_base.sv" %}
+
+{% block seq %}
+    {% sv_line_anchor %}
+    ##1;
+    cb.rst <= '0;
+    ##1;
+
+    // set all fields to all 1s
+    cb.hwif_in.r1.f_Q32_n8.next <= '1;
+    cb.hwif_in.r2.f_signed.next <= '1;
+    cb.hwif_in.r2.f_no_sign.next <= '1;
+    cpuif.write('h0, 64'hFFFF_FFFF_FFFF_FFFF);
+    cpuif.write('h8, 64'hFFFF_FFFF_FFFF_FFFF);
+    @cb;
+
+    // Q8.8
+    // verify bit range
+    assert(cb.hwif_out.r1.f_Q8_8.value[7:-8] == '1);
+    // verify bit width
+    assert($size(cb.hwif_out.r1.f_Q8_8.value) == 16);
+    // verfy unsigned
+    assert(cb.hwif_out.r1.f_Q8_8.value > 0);
+
+    // Q32.-8
+    // verify bit range
+    assert(cb.hwif_in.r1.f_Q32_n8.next[31:8] == '1);
+    // verify bit width
+    assert($size(cb.hwif_in.r1.f_Q32_n8.next) == 24);
+    // verify unsigned
+    assert(cb.hwif_in.r1.f_Q32_n8.next > 0);
+
+    // SQ-8.32
+    // verify bit range
+    assert(cb.hwif_out.r1.f_SQn8_32.value[-9:-32] == '1);
+    // verify bit width
+    assert($size(cb.hwif_out.r1.f_SQn8_32.value) == 24);
+    // verify signed
+    assert(cb.hwif_out.r1.f_SQn8_32.value < 0);
+
+    // 16-bit signed integer
+    // verify bit range
+    assert(cb.hwif_in.r2.f_signed.next[15:0] == '1);
+    // verify bit width
+    assert($size(cb.hwif_in.r2.f_signed.next) == 16);
+    // verify signed
+    assert(cb.hwif_in.r2.f_signed.next < 0);
+
+    // 16-bit unsigned integer
+    // verify bit range
+    assert(cb.hwif_out.r2.f_unsigned.value[15:0] == '1);
+    // verify bit width
+    assert($size(cb.hwif_out.r2.f_unsigned.value) == 16);
+    // verify unsigned
+    assert(cb.hwif_out.r2.f_unsigned.value > 0);
+
+    // 16-bit field (no sign)
+    // verify bit range
+    assert(cb.hwif_in.r2.f_no_sign.next[15:0] == '1);
+    // verify bit width
+    assert($size(cb.hwif_in.r2.f_no_sign.next) == 16);
+    // verify unsigned (logic is unsigned in SV)
+    assert(cb.hwif_in.r2.f_no_sign.next > 0);
+
+    // verify readback
+    cpuif.assert_read('h0, 64'hFFFF_FFFF_FFFF_FFFF);
+    cpuif.assert_read('h8, 64'h0000_FFFF_FFFF_FFFF);
+
+{% endblock %}

--- a/tests/test_fixedpoint/testcase.py
+++ b/tests/test_fixedpoint/testcase.py
@@ -1,0 +1,5 @@
+from ..lib.sim_testcase import SimTestCase
+
+class Test(SimTestCase):
+    def test_dut(self):
+        self.run_test()

--- a/tests/test_validation_errors/fixedpoint_counter.rdl
+++ b/tests/test_validation_errors/fixedpoint_counter.rdl
@@ -1,0 +1,9 @@
+addrmap top {
+    reg {
+        field {
+            sw = rw; hw = r;
+            intwidth = 4;
+            counter;
+        } fixedpoint_counter[8] = 0;
+    } r1;
+};

--- a/tests/test_validation_errors/fixedpoint_enum.rdl
+++ b/tests/test_validation_errors/fixedpoint_enum.rdl
@@ -1,0 +1,15 @@
+addrmap top {
+    reg {
+        enum test_enum {
+            zero = 2'b00;
+            one = 2'b01;
+            two = 2'b10;
+            three = 2'b11;
+        };
+        field {
+            sw = rw; hw = r;
+            fracwidth = 0;
+            encode = test_enum;
+        } fixedpoint_enum[2] = 0;
+    } r1;
+};

--- a/tests/test_validation_errors/fixedpoint_inconsistent_width.rdl
+++ b/tests/test_validation_errors/fixedpoint_inconsistent_width.rdl
@@ -1,0 +1,9 @@
+addrmap top {
+    reg {
+        field {
+            sw = rw; hw = r;
+            intwidth = 4;
+            fracwidth = 5;
+        } num[8] = 0;
+    } r1;
+};

--- a/tests/test_validation_errors/signed_counter.rdl
+++ b/tests/test_validation_errors/signed_counter.rdl
@@ -1,0 +1,14 @@
+addrmap top {
+    reg {
+        field {
+            sw = rw; hw = r;
+            is_signed = false;
+            counter;
+        } unsigned_counter[8] = 0;
+        field {
+            sw = rw; hw = r;
+            is_signed;
+            counter;
+        } signed_counter[8] = 0;
+    } r1;
+};

--- a/tests/test_validation_errors/signed_enum.rdl
+++ b/tests/test_validation_errors/signed_enum.rdl
@@ -11,5 +11,10 @@ addrmap top {
             is_signed = false;
             encode = test_enum;
         } unsigned_enum[2] = 0;
+        field {
+            sw = rw; hw = r;
+            is_signed;
+            encode = test_enum;
+        } signed_enum[2] = 0;
     } r1;
 };

--- a/tests/test_validation_errors/signed_enum.rdl
+++ b/tests/test_validation_errors/signed_enum.rdl
@@ -1,0 +1,15 @@
+addrmap top {
+    reg {
+        enum test_enum {
+            zero = 2'b00;
+            one = 2'b01;
+            two = 2'b10;
+            three = 2'b11;
+        };
+        field {
+            sw = rw; hw = r;
+            is_signed = false;
+            encode = test_enum;
+        } unsigned_enum[2] = 0;
+    } r1;
+};

--- a/tests/test_validation_errors/testcase.py
+++ b/tests/test_validation_errors/testcase.py
@@ -89,3 +89,33 @@ class TestValidationErrors(BaseTestCase):
             "unsynth_reset2.rdl",
             "A field that uses an asynchronous reset cannot use a dynamic reset value. This is not synthesizable.",
         )
+
+    def test_fixedpoint_counter(self) -> None:
+        self.assert_validate_error(
+            "fixedpoint_counter.rdl",
+            "Fixedpoint representations are not supported for counter fields.",
+        )
+
+    def test_fixedpoint_enum(self) -> None:
+        self.assert_validate_error(
+            "fixedpoint_enum.rdl",
+            "Fixedpoint representations are not supported for fields encoded as an enum.",
+        )
+
+    def test_fixedpoint_inconsistent_width(self) -> None:
+        self.assert_validate_error(
+            "fixedpoint_inconsistent_width.rdl",
+            r"Number of integer bits \(4\) plus number of fractional bits \(5\) must be equal to the width of the component \(8\).",
+        )
+
+    def test_signed_counter(self) -> None:
+        self.assert_validate_error(
+            "signed_counter.rdl",
+            "The property is_signed=true is not supported for counter fields.",
+        )
+
+    def test_signed_enum(self) -> None:
+        self.assert_validate_error(
+            "signed_enum.rdl",
+            "The is_signed property is not supported for fields encoded as an enum."
+        )

--- a/tests/test_validation_errors/testcase.py
+++ b/tests/test_validation_errors/testcase.py
@@ -93,13 +93,13 @@ class TestValidationErrors(BaseTestCase):
     def test_fixedpoint_counter(self) -> None:
         self.assert_validate_error(
             "fixedpoint_counter.rdl",
-            "Fixedpoint representations are not supported for counter fields.",
+            "Fixed-point representations are not supported for counter fields.",
         )
 
     def test_fixedpoint_enum(self) -> None:
         self.assert_validate_error(
             "fixedpoint_enum.rdl",
-            "Fixedpoint representations are not supported for fields encoded as an enum.",
+            "Fixed-point representations are not supported for fields encoded as an enum.",
         )
 
     def test_fixedpoint_inconsistent_width(self) -> None:

--- a/tests/test_validation_errors/testcase.py
+++ b/tests/test_validation_errors/testcase.py
@@ -117,5 +117,5 @@ class TestValidationErrors(BaseTestCase):
     def test_signed_enum(self) -> None:
         self.assert_validate_error(
             "signed_enum.rdl",
-            "The is_signed property is not supported for fields encoded as an enum."
+            "The property is_signed=true is not supported for fields encoded as an enum."
         )


### PR DESCRIPTION
# Description of change

Add support for the `is_signed`, `intwidth`, and `fracwidth` properties as discussed in [SystemRDL/#188](https://github.com/orgs/SystemRDL/discussions/188).

For a full description of the new features, see the updated documentation included in the PR.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x] If this change adds new features, I have added new unit tests that cover them.
