### PR TITLE
New --synth-part Argument for Synthesis Tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,17 @@ def pytest_addoption(parser):
         auto: choose the best tool based on what is installed
         """
     )
+
+    parser.addoption(
+        "--synth-part",
+        type=str,
+        default=".*",
+        help="""
+        A REGEX expression used to filter the part used for the synthesis test.
+
+        Useful when the default method for finding a part finds a part which you don't have a
+        license for.
+
+        Defaults to '.*'.
+        """
+    )

--- a/tests/lib/synth_testcase.py
+++ b/tests/lib/synth_testcase.py
@@ -1,10 +1,11 @@
-from typing import List
 import os
+from typing import List
 
 import pytest
 
 from .base_testcase import BaseTestCase
 from .synthesizers import get_synthesizer_cls
+
 
 class SynthTestCase(BaseTestCase):
 
@@ -26,7 +27,7 @@ class SynthTestCase(BaseTestCase):
     def run_synth(self) -> None:
         name = self.request.config.getoption("--synth-tool")
         synth_cls = get_synthesizer_cls(name)
-        synth = synth_cls(self)
+        synth = synth_cls(self, request=self.request)
 
         # cd into the build directory
         cwd = os.getcwd()

--- a/tests/lib/synthesizers/base.py
+++ b/tests/lib/synthesizers/base.py
@@ -1,17 +1,28 @@
 from typing import TYPE_CHECKING, List
 
+import pytest
+
 if TYPE_CHECKING:
     from ..synth_testcase import SynthTestCase
 
 class Synthesizer:
     name = ""
 
+    #: this gets auto-loaded via the _load_request autouse fixture
+    request = None # type: pytest.FixtureRequest
+
+    @pytest.fixture(autouse=True)
+    def _load_request(self, request):
+        self.request = request
+
     @classmethod
     def is_installed(cls) -> bool:
         raise NotImplementedError
 
-    def __init__(self, testcase: 'SynthTestCase' = None) -> None:
+    def __init__(self, testcase: 'SynthTestCase' = None,
+                 request: 'pytest.FixtureRequest' = None) -> None:
         self.testcase = testcase
+        self.request = request
 
     def run(self) -> None:
         raise NotImplementedError

--- a/tests/lib/synthesizers/vivado.py
+++ b/tests/lib/synthesizers/vivado.py
@@ -1,8 +1,9 @@
 import os
-import subprocess
 import shutil
+import subprocess
 
 from .base import Synthesizer
+
 
 class Vivado(Synthesizer):
     name = "vivado"
@@ -22,7 +23,7 @@ class Vivado(Synthesizer):
             "-mode", "batch",
             "-log", "out.log",
             "-source", script,
-            "-tclargs"
+            "-tclargs", self.request.config.getoption("--synth-part")
         ]
         cmd.extend(self.testcase._get_synth_files())
 

--- a/tests/lib/synthesizers/vivado_scripts/run.tcl
+++ b/tests/lib/synthesizers/vivado_scripts/run.tcl
@@ -1,5 +1,7 @@
 set this_dir [file dirname [file normalize [info script]]]
-set files $argv
+set files [lrange $argv 1 end]
+
+set part_regex [lindex $argv 0]
 
 
 # Multi-driven
@@ -22,7 +24,7 @@ set_msg_config -id {[Synth 8-295]} -new_severity "ERROR"
 set_msg_config -severity {CRITICAL WARNING} -new_severity "ERROR"
 
 
-set_part [lindex [get_parts] 0]
+set_part [lindex [get_parts -regex $part_regex] 0]
 read_verilog -sv $files
 read_xdc $this_dir/constr.xdc
 synth_design -top regblock -mode out_of_context


### PR DESCRIPTION
Added the ability to specify a regex filter for the part-name on the synthesis tests. Implemented as --synth-part. Closes #179

# Description of change

Describe what bug or feature your pull request addresses.
If applicable, provide a link to the relevant issue ticket or discussion about
this change.

# Checklist

- [X] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [X] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [X] If this change adds new features, I have added new unit tests that cover them.
