### PR TITLE
Improve test naming.

### DIFF
--- a/tests/lib/test_params.py
+++ b/tests/lib/test_params.py
@@ -1,7 +1,20 @@
 from itertools import product
 
+
 def get_permutations(spec):
     param_list = []
     for v in product(*spec.values()):
         param_list.append(dict(zip(spec, v)))
     return param_list
+
+
+def get_permutation_class_name(cls, num: int, params: dict) -> str:
+    class_name = cls.__name__
+
+    for val in params.values():
+        val_str = str(val)
+        if "object at" in val_str:
+            val_str = type(val).__name__
+        class_name += f"_{val_str}"
+
+    return class_name

--- a/tests/test_cpuif_err_rsp/testcase.py
+++ b/tests/test_cpuif_err_rsp/testcase.py
@@ -1,8 +1,9 @@
 from parameterized import parameterized_class
 
-from ..lib.sim_testcase import SimTestCase
-from ..lib.test_params import get_permutations
 from ..lib.cpuifs import ALL_CPUIF
+from ..lib.sim_testcase import SimTestCase
+from ..lib.test_params import get_permutation_class_name, get_permutations
+
 
 @parameterized_class(
     # To reduce the number of tests, cover all CPUIFs with both error injections enabled, and all
@@ -15,7 +16,8 @@ from ..lib.cpuifs import ALL_CPUIF
     get_permutations({
         "err_if_bad_addr": [True, False],
         "err_if_bad_rw": [True, False],
-    })
+    }),
+    class_name_func=get_permutation_class_name
 )
 class Test(SimTestCase):
     extra_tb_files = [

--- a/tests/test_external/testcase.py
+++ b/tests/test_external/testcase.py
@@ -1,10 +1,11 @@
 from parameterized import parameterized_class
 
-from ..lib.sim_testcase import SimTestCase
-from ..lib.test_params import get_permutations
 from ..lib.cpuifs.apb4 import APB4
 from ..lib.cpuifs.axi4lite import AXI4Lite
 from ..lib.cpuifs.passthrough import Passthrough
+from ..lib.sim_testcase import SimTestCase
+from ..lib.test_params import get_permutation_class_name, get_permutations
+
 
 @parameterized_class(get_permutations({
     "cpuif": [
@@ -15,7 +16,7 @@ from ..lib.cpuifs.passthrough import Passthrough
     "retime_read_fanin": [True, False],
     "retime_read_response": [True, False],
     "retime_external": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class Test(SimTestCase):
     extra_tb_files = [
         "../lib/external_reg.sv",

--- a/tests/test_pipelined_cpuif/testcase.py
+++ b/tests/test_pipelined_cpuif/testcase.py
@@ -1,14 +1,15 @@
 from parameterized import parameterized_class
 
-from ..lib.sim_testcase import SimTestCase
-from ..lib.test_params import get_permutations
 from ..lib.cpuifs import ALL_CPUIF
+from ..lib.sim_testcase import SimTestCase
+from ..lib.test_params import get_permutation_class_name, get_permutations
+
 
 @parameterized_class(get_permutations({
     "cpuif": ALL_CPUIF,
     "retime_read_fanin": [True, False],
     "retime_read_response": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class Test(SimTestCase):
     def test_dut(self):
         self.run_test()

--- a/tests/test_pkg_params/testcase.py
+++ b/tests/test_pkg_params/testcase.py
@@ -1,14 +1,14 @@
 from parameterized import parameterized_class
 
 from ..lib.sim_testcase import SimTestCase
-from ..lib.test_params import get_permutations
+from ..lib.test_params import get_permutation_class_name, get_permutations
 
 PARAMS = get_permutations({
     "n_regs" : [1, 2],
     "regwidth" : [8, 16],
     "name" : ["hello", "world"],
 })
-@parameterized_class(PARAMS)
+@parameterized_class(PARAMS, class_name_func=get_permutation_class_name)
 class TestRetimedFanin(SimTestCase):
     n_regs = 20
     regwidth = 32

--- a/tests/test_read_fanin/testcase.py
+++ b/tests/test_read_fanin/testcase.py
@@ -1,13 +1,12 @@
 from parameterized import parameterized_class
 
 from ..lib.sim_testcase import SimTestCase
-from ..lib.test_params import get_permutations
-
+from ..lib.test_params import get_permutation_class_name, get_permutations
 
 PARAMS = get_permutations({
     "regwidth" : [8, 16, 32, 64],
 })
-@parameterized_class(PARAMS)
+@parameterized_class(PARAMS, class_name_func=get_permutation_class_name)
 class TestFanin(SimTestCase):
     retime_read_fanin = False
     n_regs = 20
@@ -29,7 +28,7 @@ PARAMS = get_permutations({
     "n_regs" : [1, 4, 7, 9, 11],
     "regwidth" : [8, 16, 32, 64],
 })
-@parameterized_class(PARAMS)
+@parameterized_class(PARAMS, class_name_func=get_permutation_class_name)
 class TestRetimedFanin(TestFanin):
     retime_read_fanin = True
 

--- a/tests/test_structural_sw_rw/testcase.py
+++ b/tests/test_structural_sw_rw/testcase.py
@@ -2,28 +2,25 @@ import os
 
 from parameterized import parameterized_class
 
+from ..lib.cpuifs import ALL_CPUIF
 from ..lib.sim_testcase import SimTestCase
 from ..lib.synth_testcase import SynthTestCase
-from ..lib.test_params import get_permutations
-from ..lib.cpuifs import ALL_CPUIF
-
-
+from ..lib.test_params import get_permutation_class_name, get_permutations
 
 
 @parameterized_class(get_permutations({
     "cpuif": ALL_CPUIF,
     "retime_read_fanin": [True, False],
     "retime_read_response": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class TestCPUIFS(SimTestCase):
     def test_dut(self):
         self.run_test()
 
 
-
 @parameterized_class(get_permutations({
     "reuse_hwif_typedefs": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class TestTypedefs(SimTestCase):
     def test_dut(self):
         self.run_test()
@@ -33,7 +30,7 @@ class TestTypedefs(SimTestCase):
 @parameterized_class(get_permutations({
     "default_reset_activelow": [True, False],
     "default_reset_async": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class TestDefaultResets(SimTestCase):
     def test_dut(self):
         self.run_test()
@@ -45,7 +42,7 @@ class TestDefaultResets(SimTestCase):
     "retime_read_fanin": [True, False],
     "retime_read_response": [True, False],
     "reuse_hwif_typedefs": [True, False],
-}))
+}), class_name_func=get_permutation_class_name)
 class TestSynth(SynthTestCase):
     def test_dut(self):
         self.run_synth()


### PR DESCRIPTION
Improved the naming of tests which use the 'get_permutations' function. Adds the parameter values to the end of the test class.

# Description of change

In the existing code base when a the test classes are parameterized they have a number appended to them. This means it can be difficult to tell which particular parameters a test is run with without looking at the underlying logs. 

This change works by adding the parameter values (or in the cause of objects without a custom `__str__` the type-name) to the TestClass name.

Example: 
`TestCPUIFS_47` becomes `TestCPUIFS_OBI_FALSE_FALSE` where `OBI_FALSE_FALSE` refers to the three parameters used.

# Checklist

- [X] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [X] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [X] If this change adds new features, I have added new unit tests that cover them.
