### PR TITLE
fix: Implement address masking for AXI4-Lite

### DIFF
--- a/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
+++ b/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
@@ -96,27 +96,27 @@ always_comb begin
             cpuif_req = '1;
             cpuif_req_is_wr = '0;
             {%- if cpuif.data_width_bytes == 1 %}
-            cpuif_addr = axil_araddr;
+            cpuif_addr = axil_araddr & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- else %}
-            cpuif_addr = {axil_araddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0};
+            cpuif_addr = {axil_araddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0} & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- endif %}
             if(!cpuif_req_stall_rd) axil_ar_accept = '1;
         end else if(axil_awvalid && axil_wvalid) begin
             cpuif_req = '1;
             cpuif_req_is_wr = '1;
             {%- if cpuif.data_width_bytes == 1 %}
-            cpuif_addr = axil_awaddr;
+            cpuif_addr = axil_awaddr & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- else %}
-            cpuif_addr = {axil_awaddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0};
+            cpuif_addr = {axil_awaddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0} & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- endif %}
             if(!cpuif_req_stall_wr) axil_aw_accept = '1;
         end else if(axil_arvalid) begin
             cpuif_req = '1;
             cpuif_req_is_wr = '0;
             {%- if cpuif.data_width_bytes == 1 %}
-            cpuif_addr = axil_araddr;
+            cpuif_addr = axil_araddr & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- else %}
-            cpuif_addr = {axil_araddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0};
+            cpuif_addr = {axil_araddr[{{cpuif.addr_width-1}}:{{clog2(cpuif.data_width_bytes)}}], {{clog2(cpuif.data_width_bytes)}}'b0} & {{cpuif.addr_width}}'h{{"%x" % cpuif.addr_mask}};
             {%- endif %}
             if(!cpuif_req_stall_rd) axil_ar_accept = '1;
         end

--- a/src/peakrdl_regblock/cpuif/base.py
+++ b/src/peakrdl_regblock/cpuif/base.py
@@ -19,6 +19,10 @@ class CpuifBase:
         self.reset = exp.ds.top_node.cpuif_reset
 
     @property
+    def addr_mask(self) -> int:
+        return self.exp.ds.addr_mask
+
+    @property
     def addr_width(self) -> int:
         return self.exp.ds.addr_width
 

--- a/src/peakrdl_regblock/exporter.py
+++ b/src/peakrdl_regblock/exporter.py
@@ -322,6 +322,7 @@ class DesignState:
         #------------------------
         # Min address width encloses the total size AND at least 1 useful address bit
         self.addr_width = max(clog2(self.top_node.size), clog2(self.cpuif_data_width//8) + 1)
+        self.addr_mask = (1 << self.addr_width) - 1
 
         if user_addr_width is not None:
             if user_addr_width < self.addr_width:


### PR DESCRIPTION
Introduces an address masking mechanism for the AXI4-Lite CPU interface. The address mask is calculated in DesignState, exposed via the CpuifBase, and applied in the AXI4-Lite SystemVerilog template to ensure address alignment and proper access within the defined address space.

Closes #185

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)

