### PR TITLE
Skip read/write buffering implementation for external nodes

### DIFF
--- a/src/peakrdl_regblock/read_buffering/implementation_generator.py
+++ b/src/peakrdl_regblock/read_buffering/implementation_generator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from systemrdl.node import RegNode, AddressableNode
 from systemrdl.walker import WalkerAction
@@ -18,7 +18,7 @@ class RBufLogicGenerator(RDLForLoopGenerator):
             "read_buffering/template.sv"
         )
 
-    def enter_AddressableComponent(self, node: AddressableNode) -> WalkerAction:
+    def enter_AddressableComponent(self, node: AddressableNode) -> Optional[WalkerAction]:
         if node.external:
             return WalkerAction.SkipDescendants
         return super().enter_AddressableComponent(node)

--- a/src/peakrdl_regblock/write_buffering/implementation_generator.py
+++ b/src/peakrdl_regblock/write_buffering/implementation_generator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from collections import namedtuple
 
 from systemrdl.node import RegNode, AddressableNode
@@ -19,7 +19,7 @@ class WBufLogicGenerator(RDLForLoopGenerator):
             "write_buffering/template.sv"
         )
 
-    def enter_AddressableComponent(self, node: AddressableNode) -> WalkerAction:
+    def enter_AddressableComponent(self, node: AddressableNode) -> Optional[WalkerAction]:
         if node.external:
             return WalkerAction.SkipDescendants
         return super().enter_AddressableComponent(node)


### PR DESCRIPTION
# Description of change

Yet another fix for yet another edge case regarding #167. The original fix didn't really work due to https://github.com/SystemRDL/PeakRDL-regblock/issues/167#issuecomment-3499881064. A fix was made in https://github.com/SystemRDL/PeakRDL-regblock/commit/61bffb7b91bbb8c2ff9967b8c0358f3959d70d9c but it only fixed it for the storage generators, not the implementation generators.

This PR adds the fix for the implementation generators as well.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x] If this change adds new features, I have added new unit tests that cover them.
