### PR TITLE
Addressing issue #193: fixing BLKLOOPINIT Verilator error by replace …

### DIFF
--- a/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
+++ b/src/peakrdl_regblock/cpuif/axi4lite/axi4lite_tmpl.sv
@@ -164,11 +164,9 @@ always_comb begin
 end
 
 {%- else %}
-struct {
-    logic is_wr;
-    logic err;
-    logic [{{cpuif.data_width-1}}:0] rdata;
-} axil_resp_buffer[{{roundup_pow2(cpuif.resp_buffer_size)}}];
+logic axil_resp_buffer_is_wr[{{roundup_pow2(cpuif.resp_buffer_size)}}];
+logic axil_resp_buffer_err[{{roundup_pow2(cpuif.resp_buffer_size)}}];
+logic [{{cpuif.data_width-1}}:0] axil_resp_buffer_rdata[{{roundup_pow2(cpuif.resp_buffer_size)}}];
 {%- if not is_pow2(cpuif.resp_buffer_size) %}
 // axil_resp_buffer is intentionally padded to the next power of two despite
 // only requiring {{cpuif.resp_buffer_size}} entries.
@@ -182,9 +180,9 @@ logic [{{clog2(cpuif.resp_buffer_size)}}:0] axil_resp_rptr;
 always_ff {{get_always_ff_event(cpuif.reset)}} begin
     if({{get_resetsignal(cpuif.reset)}}) begin
         for(int i=0; i<{{cpuif.resp_buffer_size}}; i++) begin
-            axil_resp_buffer[i].is_wr <= '0;
-            axil_resp_buffer[i].err <= '0;
-            axil_resp_buffer[i].rdata <= '0;
+            axil_resp_buffer_is_wr[i] <= '0;
+            axil_resp_buffer_err[i] <= '0;
+            axil_resp_buffer_rdata[i] <= '0;
         end
         axil_resp_wptr <= '0;
         axil_resp_rptr <= '0;
@@ -192,13 +190,13 @@ always_ff {{get_always_ff_event(cpuif.reset)}} begin
         // Store responses in buffer until AXI response channel accepts them
         if(cpuif_rd_ack || cpuif_wr_ack) begin
             if(cpuif_rd_ack) begin
-                axil_resp_buffer[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].is_wr <= '0;
-                axil_resp_buffer[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].err <= cpuif_rd_err;
-                axil_resp_buffer[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].rdata <= cpuif_rd_data;
+                axil_resp_buffer_is_wr[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]] <= '0;
+                axil_resp_buffer_err[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]] <= cpuif_rd_err;
+                axil_resp_buffer_rdata[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]] <= cpuif_rd_data;
 
             end else if(cpuif_wr_ack) begin
-                axil_resp_buffer[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].is_wr <= '1;
-                axil_resp_buffer[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].err <= cpuif_wr_err;
+                axil_resp_buffer_is_wr[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]] <= '1;
+                axil_resp_buffer_err[axil_resp_wptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]] <= cpuif_wr_err;
             end
             {%- if is_pow2(cpuif.resp_buffer_size) %}
             axil_resp_wptr <= axil_resp_wptr + 1'b1;
@@ -233,7 +231,7 @@ always_comb begin
     {{cpuif.signal("bvalid")}} = '0;
     {{cpuif.signal("rvalid")}} = '0;
     if(axil_resp_rptr != axil_resp_wptr) begin
-        if(axil_resp_buffer[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].is_wr) begin
+        if(axil_resp_buffer_is_wr[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]]) begin
             {{cpuif.signal("bvalid")}} = '1;
             if({{cpuif.signal("bready")}}) axil_resp_acked = '1;
         end else begin
@@ -242,8 +240,8 @@ always_comb begin
         end
     end
 
-    {{cpuif.signal("rdata")}} = axil_resp_buffer[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].rdata;
-    if(axil_resp_buffer[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]].err) begin
+    {{cpuif.signal("rdata")}} = axil_resp_buffer_rdata[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]];
+    if(axil_resp_buffer_err[axil_resp_rptr[{{clog2(cpuif.resp_buffer_size)-1}}:0]]) begin
         {{cpuif.signal("bresp")}} = 2'b10;
         {{cpuif.signal("rresp")}} = 2'b10;
     end else begin


### PR DESCRIPTION
Refer to Issue #193 for details on what this Pull Request addresses. In summary though,
The anonymous struct array:

```verilog
struct {
    logic is_wr;
    logic err;
    logic [N:0] rdata;
} axil_resp_buffer[SIZE];
```
Was replaced with three flat arrays:

```verilog
logic axil_resp_buffer_is_wr[SIZE];
logic axil_resp_buffer_err[SIZE];
logic [N:0] axil_resp_buffer_rdata[SIZE];
```
All 13 field accesses across the declaration, reset loop, write assignments, and read combinational block were updated accordingly.