### PR TITLE
fix width mismatch in counter overflow calculation (#197)

### DIFF
--- a/src/peakrdl_regblock/field_logic/templates/counter_macros.sv
+++ b/src/peakrdl_regblock/field_logic/templates/counter_macros.sv
@@ -7,7 +7,7 @@
             next_c = next_c + {{field_logic.get_counter_incrvalue(node)}};
         end
         {%- else %}
-        {{field_logic.get_field_combo_identifier(node, "overflow")}} = ((({{node.width+1}})'(next_c) + {{field_logic.get_counter_incrvalue(node)}}) > {{get_value(2**node.width - 1, node.width)}});
+        {{field_logic.get_field_combo_identifier(node, "overflow")}} = ((({{node.width+1}})'(next_c) + {{field_logic.get_counter_incrvalue(node)}}) > {{get_value(2**node.width - 1, node.width + 1)}});
         next_c = next_c + {{field_logic.get_counter_incrvalue(node)}};
         {%- endif %}
         load_next_c = '1;


### PR DESCRIPTION
# Description of change

This fixes a Verilator error when generating counter registers. I **have not** run the unit test suite due to not being able to install Questa locally, but VCS and Verilator simulate correctly.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock/blob/main/CONTRIBUTING.md)
- [ ] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [x] If this change adds new features, I have added new unit tests that cover them.
